### PR TITLE
Update `apm` script to use `$AIR_HOME` if set

### DIFF
--- a/client/src/apm
+++ b/client/src/apm
@@ -1,4 +1,10 @@
 #!/bin/bash
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 #$SCRIPT_DIR/apm.app/Contents/MacOS/apm -workingdir "`pwd`" $@
-adl -profile extendedDesktop -cmd "$SCRIPT_DIR/apm.xml" -- -workingdir "`pwd`" -appdir "$SCRIPT_DIR" $@
+
+# if AIR_HOME environment variable is set, look for "adl" in AIR_HOME/bin directory
+if [ -z "$ADL_DIR" ] && [ ! -z "$AIR_HOME" ]; then
+  ADL_DIR="$AIR_HOME/bin/"
+fi
+
+${ADL_DIR}adl -profile extendedDesktop -cmd "$SCRIPT_DIR/apm.xml" -- -workingdir "`pwd`" -appdir "$SCRIPT_DIR" $@


### PR DESCRIPTION
I don't put Air in my PATH (some tool names conflict with other framework I use), so I like to have the option to give `apm` the directory to look `adl` into.