### PR TITLE
Fix bash script

### DIFF
--- a/client/src/apm
+++ b/client/src/apm
@@ -7,4 +7,4 @@ if [ -z "$ADL_DIR" ] && [ ! -z "$AIR_HOME" ]; then
   ADL_DIR="$AIR_HOME/bin/"
 fi
 
-${ADL_DIR}adl -profile extendedDesktop -cmd "$SCRIPT_DIR/apm.xml" -- -workingdir "`pwd`" -appdir "$SCRIPT_DIR" $@
+${ADL_DIR}adl -profile extendedDesktop -cmd "$SCRIPT_DIR/apm.xml" -- -workingdir "$( pwd )" -appdir "$SCRIPT_DIR" "$@"


### PR DESCRIPTION
- The backticks is the legacy syntax required by only the very oldest of
  non-POSIX-compatible bourne-shells and `$(...)` is POSIX and more preferred
  for several reasons: see https://stackoverflow.com/a/33301370
- `$@` should be included in double quotes: `"$@"` (or arguments like paths
  containing spaces will fail).