### PR TITLE
Change apm repository with env `APM_REPOSITORY`

### DIFF
--- a/client/src/com/apm/client/config/RunConfig.as
+++ b/client/src/com/apm/client/config/RunConfig.as
@@ -40,6 +40,7 @@ package com.apm.client.config
 		
 		private static const TAG:String = "RunConfig";
 		
+		public static const DEFAULT_REPOSITORY_URL:String = "https://repository.airsdk.dev";
 		
 		////////////////////////////////////////////////////////
 		//  VARIABLES
@@ -210,6 +211,17 @@ package com.apm.client.config
 			
 			throw new Error( "Failed to find '" + javaBinPath + "' in JAVA_HOME=" + javaHome
 									 + ". Point JAVA_HOME to your java installation." );
+		}
+		
+		
+		public function getDefaultRemoteRepositoryEndpoint():String
+		{
+			if (env["APM_REPOSITORY"])
+			{
+				Log.d( TAG, "Using custom apm repository: " + env["APM_REPOSITORY"] );
+				return env["APM_REPOSITORY"];
+			}
+			return DEFAULT_REPOSITORY_URL;
 		}
 		
 		

--- a/client/src/com/apm/client/repositories/RepositoryResolver.as
+++ b/client/src/com/apm/client/repositories/RepositoryResolver.as
@@ -28,8 +28,6 @@ package com.apm.client.repositories
 		
 		private static const TAG:String = "RepositoryResolver";
 		
-		public static const DEFAULT_REPOSITORY_URL:String = "https://repository.airsdk.dev";
-		
 		
 		////////////////////////////////////////////////////////
 		//  VARIABLES
@@ -72,7 +70,7 @@ package com.apm.client.repositories
 					}
 				}
 			}
-			return new RepositoryAPI( DEFAULT_REPOSITORY_URL );
+			return new RepositoryAPI( APM.config.getDefaultRemoteRepositoryEndpoint() );
 		}
 		
 	}


### PR DESCRIPTION
Second take on this, only touching `client` classes this time.

Same thing as #27, set the `APM_REPOSITORY` to change the APM repository used by all commands.

Handy for specifying which repository to use when publishing / searching / installing packages, in dev, or when deploying a custom repository for a team.

Example use:

```
APM_REPOSITORY=http://localhost:3000 apm publish
```