### PR TITLE
Fix #35 - Omit github tokens form unauthorized domains

### DIFF
--- a/client/src/com/apm/client/commands/packages/utils/PackageRequestUtils.as
+++ b/client/src/com/apm/client/commands/packages/utils/PackageRequestUtils.as
@@ -129,12 +129,15 @@ package com.apm.client.commands.packages.utils
 			var headers:Array = [];
 			headers.push( new URLRequestHeader( "User-Agent", "apm v" + new SemVer( Consts.VERSION ).toString() ) );
 			
-			if (url.indexOf( "github.com" ) >= 0 && githubToken.length > 0)
+			if (url.indexOf( "https://api.github.com/" ) == 0 && githubToken.length > 0)
 			{
 				headers.push( new URLRequestHeader( "Accept", "application/octet-stream" ) );
 	
 				if (githubToken != null && githubToken.length > 0)
+				{
+					Log.d( TAG, "generateURLRequest(): Attaching github auth token." );
 					headers.push( new URLRequestHeader( "Authorization", "token " + githubToken ) );
+				}
 			}
 			
 			var req:URLRequest = new URLRequest( url );


### PR DESCRIPTION
Only URLs starting with `https://api.github.com/` should receive the github auth token.