### PR TITLE
Refactor project config template engine

### DIFF
--- a/client/src/com/apm/client/commands/project/processes/IOSAdditionsMergeProcess.as
+++ b/client/src/com/apm/client/commands/project/processes/IOSAdditionsMergeProcess.as
@@ -19,6 +19,7 @@ package com.apm.client.commands.project.processes
 	import com.apm.client.processes.ProcessQueue;
 	import com.apm.data.project.ApplicationDescriptor;
 	import com.apm.utils.FileUtils;
+	import com.apm.utils.Template;
 	import com.apple.plist.Plist;
 	
 	import flash.filesystem.File;
@@ -63,17 +64,7 @@ package com.apm.client.commands.project.processes
 			if (infoAdditionsProjectFile.exists)
 			{
 				APM.io.writeLine( "Merging with supplied info additions: config/ios/InfoAdditions.xml" );
-				
-				// Read content and inject any config parameters
-				var infoAdditionsProjectContent:String = FileUtils.readFileContentAsString( infoAdditionsProjectFile );
-				for (var name:String in APM.config.projectDefinition.configuration)
-				{
-					var regex:RegExp = new RegExp( "\\$\\{" + name + "\\}", "g" );
-					var value:String = APM.config.projectDefinition.getConfigurationParam( name );
-					
-					infoAdditionsProjectContent = infoAdditionsProjectContent.replace( regex, value );
-				}
-				FileUtils.writeStringAsFileContent( infoAdditionsFile, infoAdditionsProjectContent );
+				Template.compileFileToFile( infoAdditionsProjectFile, infoAdditionsFile, APM.config.projectDefinition.configuration );
 			}
 			else
 			{

--- a/client/src/com/apm/client/commands/project/processes/IOSEntitlementsMergeProcess.as
+++ b/client/src/com/apm/client/commands/project/processes/IOSEntitlementsMergeProcess.as
@@ -19,6 +19,7 @@ package com.apm.client.commands.project.processes
 	import com.apm.client.processes.ProcessQueue;
 	import com.apm.data.project.ApplicationDescriptor;
 	import com.apm.utils.FileUtils;
+	import com.apm.utils.Template;
 	import com.apple.plist.Plist;
 	
 	import flash.filesystem.File;
@@ -63,17 +64,8 @@ package com.apm.client.commands.project.processes
 			if (entitlementsProjectFile.exists)
 			{
 				APM.io.writeLine( "Merging with supplied info additions: config/ios/Entitlements.xml" );
-				
-				// Read content and inject any config parameters
-				var entitlementsProjectContent:String = FileUtils.readFileContentAsString( entitlementsProjectFile );
-				for (var name:String in APM.config.projectDefinition.configuration)
-				{
-					var regex:RegExp = new RegExp( "\\$\\{" + name + "\\}", "g" );
-					var value:String = APM.config.projectDefinition.getConfigurationParam( name );
-					
-					entitlementsProjectContent = entitlementsProjectContent.replace( regex, value );
-				}
-				FileUtils.writeStringAsFileContent( entitlementsFile, entitlementsProjectContent );
+				Template.compileFileToFile( entitlementsProjectFile, entitlementsFile,
+					APM.config.projectDefinition.configuration );
 			}
 			else
 			{

--- a/client/src/com/apm/client/commands/project/processes/IOSPlistMergeProcess.as
+++ b/client/src/com/apm/client/commands/project/processes/IOSPlistMergeProcess.as
@@ -15,7 +15,7 @@ package com.apm.client.commands.project.processes
 {
 	import com.apm.client.APM;
 	import com.apm.client.processes.ProcessBase;
-	import com.apm.utils.FileUtils;
+	import com.apm.utils.Template;
 	import com.apple.plist.Plist;
 	import com.apple.plist.PlistUtils;
 	
@@ -64,14 +64,8 @@ package com.apm.client.commands.project.processes
 			{
 				// Insert configuration parameters into merge plist
 				// Note: currentPlist should already have parameters
-				var mergeContent:String = FileUtils.readFileContentAsString( _mergePlist );
-				for (var name:String in APM.config.projectDefinition.configuration)
-				{
-					var regex:RegExp = new RegExp( "\\$\\{" + name + "\\}", "g" );
-					var value:String = APM.config.projectDefinition.getConfigurationParam( name );
-					
-					mergeContent = mergeContent.replace( regex, value );
-				}
+				var mergeContent:String =
+					Template.compileFile( _mergePlist, APM.config.projectDefinition.configuration );
 				
 				// Load and merge plists
 				var merge:Plist = new Plist( mergeContent );

--- a/client/src/com/apm/utils/Template.as
+++ b/client/src/com/apm/utils/Template.as
@@ -1,0 +1,49 @@
+/**
+ * @author 		Jean-Christophe Hoelt (https://github.com/j3k0)
+ * @created		23/9/21
+ */
+package com.apm.utils
+{
+	import com.apm.client.logging.Log;
+	import com.apm.utils.FileUtils;
+	import flash.filesystem.File;
+	
+	public class Template
+	{
+		public static function compile( content:String, configuration:Object ):String
+		{
+			var output:String = content;
+			for (var name:String in configuration)
+			{
+				var regex:RegExp = new RegExp( "\\$\\{[ \t]*" + name + "[ \t]*\\}", "g" );
+				var value:String = getParam( configuration, name );
+				
+				output = output.replace( regex, value );
+			}
+			return output;
+		}
+
+		public static function compileFile( inputFile:File, configuration:Object ):String
+		{
+			var content:String = FileUtils.readFileContentAsString( inputFile );
+			return compile( content, configuration );
+		}
+
+		public static function compileFileToFile( inputFile:File, outputFile:File, configuration:Object ):String
+		{
+			var content:String = FileUtils.readFileContentAsString( inputFile );
+			var compiled:String = compile( content, configuration );
+			FileUtils.writeStringAsFileContent( outputFile, compiled );
+			return compiled;
+		}
+
+		private static function getParam( configuration:Object, key:String ):String
+		{
+			if (configuration.hasOwnProperty( key ))
+			{
+				return configuration[ key ];
+			}
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
 - Adds the option to add separators within the `${...}` variables.
 - More ambitious goal I have in mind would be to support conditionals (will discuss this in an issue).