### PR TITLE
Override project configuration with environment variables

### DIFF
--- a/client/src/com/apm/client/config/RunConfig.as
+++ b/client/src/com/apm/client/config/RunConfig.as
@@ -125,6 +125,65 @@ package com.apm.client.config
 		}
 		
 		
+		public function loadProjectDefinition( f:File ):void
+		{
+			Log.d( TAG, "loading project configuration..." );
+			projectDefinition = new ProjectDefinition();
+			projectDefinition.load( f );
+
+			// override the project configuration with environment variables.
+			// a configuration which as this form "helloAIRDev" will be read from env.HELLO_AIR_DEV
+			for (var name:String in projectDefinition.configuration)
+			{
+				var envName:String = getEnvNameForConfig( name );
+//				Log.d( TAG, "Configuration " + name + " can be set with environment " + envName );
+				if ( env.hasOwnProperty( envName ) )
+				{
+					// replace if set
+					Log.l( TAG, "Replacing configuration " + name + " with environment " + envName + "=" + env[envName] );
+					projectDefinition.setConfigurationParam( name, env[envName] );
+				}
+			}
+//			Log.d( TAG, "Project definition: " + JSON.stringify(projectDefinition) );
+			
+			// we'll compute here the environment name that relates to the given configuration variable
+			function getEnvNameForConfig( name:String ):String
+			{
+				var envName:String = name;
+				
+				// handle special cases like "AIRValue" and "SomeAIRValue"
+				var regexp:RegExp = /[A-Z][A-Z]+[a-z]/g;
+				regexp.lastIndex = 1;
+				var result:Object = regexp.exec(envName);
+				while (result != null) {
+					// result string is set to lowercase so it wont match the regexp anymore
+					var match:String = result[0].toLowerCase();
+					envName =
+						envName.slice(0, result.index) + 
+						'_' + match.slice(0, match.length - 2) + '_' + match.slice(-1) +
+						envName.slice(result.index + match.length);
+					result = regexp.exec(envName);
+				}
+				
+				// standalone words like "helloWorld" replaced with "hello_world"
+				regexp = /[a-z][A-Z][a-z]/g;
+				result = regexp.exec(envName);
+				while (result != null) {
+					var match:String = result[0];
+					envName =
+						envName.slice(0, result.index) + 
+						match.charAt(0) + '_' + match.slice(1).toLowerCase() +
+						envName.slice(result.index + match.length);
+					result = regexp.exec(envName);
+				}
+				
+				// environment variables are traditionally in uppercase.
+				envName = envName.toUpperCase();
+				return envName;
+			}
+		}
+		
+		
 		public function getHomeDirectory():String
 		{
 			if (isMacOS)

--- a/client/src/com/apm/client/config/processes/LoadProjectDefinitionProcess.as
+++ b/client/src/com/apm/client/config/processes/LoadProjectDefinitionProcess.as
@@ -62,8 +62,7 @@ package com.apm.client.config.processes
 				if (f.exists)
 				{
 					Log.d( TAG, "found project file - loading ..." );
-					_config.projectDefinition = new ProjectDefinition();
-					_config.projectDefinition.load( f );
+					_config.loadProjectDefinition( f );
 				}
 				complete();
 			}


### PR DESCRIPTION
A configuration with name "helloAIRDev" will be read from env["HELLO_AIR_DEV"].

For example, `apm` can be called this way when generating a production build:

```
$ APS_ENVIRONMENT=production apm generate app-descriptor
```

The project configuration doesn't have to be edited.