### PR TITLE
Improve app-descriptor validation error reports

### DIFF
--- a/client/src/com/apm/client/commands/project/processes/ApplicationDescriptorGenerationProcess.as
+++ b/client/src/com/apm/client/commands/project/processes/ApplicationDescriptorGenerationProcess.as
@@ -76,16 +76,20 @@ package com.apm.client.commands.project.processes
 				
 				if (configDescriptor.exists)
 				{
+					Log.d( TAG, "Loading config/application-descriptor.xml" );
 					_appDescriptor.load( configDescriptor );
 				}
 				else if (specifiedDescriptor.exists)
 				{
+					Log.d( TAG, "Loading " + _outputPath );
 					_appDescriptor.load( specifiedDescriptor );
 				}
 				
 				// Check if the loaded descriptor is valid, otherwise use the template
 				if (!_appDescriptor.isValid())
 				{
+					Log.d( TAG, "Invalid application descriptor, using the template" );
+					Log.l( TAG, _appDescriptor.validate() );
 					_appDescriptor.loadString( ApplicationDescriptor.APPLICATION_DESCRIPTOR_TEMPLATE );
 				}
 				

--- a/client/src/com/apm/data/project/ApplicationDescriptor.as
+++ b/client/src/com/apm/data/project/ApplicationDescriptor.as
@@ -182,22 +182,27 @@ package com.apm.data.project
 		//
 		// LOADING / SAVING
 		//
-		
-		public function isValid():Boolean
+
+		public function validate():String
 		{
 			try
 			{
 				// TODO:: Some better validation on the descriptor
-				if (_xml == null) return false;
-				if (_xml.toXMLString().length == 0) return false;
-				if (String(_xml.name()).indexOf( "application" ) < 0) return false;
-				if (_xml.id == undefined) return false;
-				return true;
+				if (_xml == null) return "XML can't be parsed (null)";
+				if (_xml.toXMLString().length == 0) return "XML is empty or invalid";
+				if (String(_xml.name()).indexOf( "application" ) < 0) return "root tag <application> not found";
+				if (_xml.id == undefined) return "<id> tag not found";
+				return null;
 			}
 			catch (e:Error)
 			{
+				return e.message;
 			}
-			return false;
+		}
+		
+		public function isValid():Boolean
+		{
+			return validate() == null;
 		}
 		
 		


### PR DESCRIPTION
The new `ApplicationDescriptor.validate()` function returns the validation error as a String.

---

Had to debug some issue where the template was being used, had to figure out why. Added some logs and improved the error reporting.