### PR TITLE
Fix publish when package has dependencies

### DIFF
--- a/client/src/com/apm/client/repositories/PackageResolver.as
+++ b/client/src/com/apm/client/repositories/PackageResolver.as
@@ -75,16 +75,19 @@ package com.apm.client.repositories
 			// TODO:: Implement source
 			var searchQueue:ProcessQueue = new ProcessQueue();
 			var repo:Repository;
-			for each (var repository:RepositoryDefinition in APM.config.projectDefinition.repositories)
+			if (APM.config.projectDefinition)
 			{
-				searchQueue.addProcess(
-						new RepositoryGetPackageVersionProcess(
-								this,
-								RepositoryResolver.repositoryForSource( repository.name ),
-								identifier,
-								version
-						)
-				);
+				for each (var repository:RepositoryDefinition in APM.config.projectDefinition.repositories)
+				{
+					searchQueue.addProcess(
+							new RepositoryGetPackageVersionProcess(
+									this,
+									RepositoryResolver.repositoryForSource( repository.name ),
+									identifier,
+									version
+							)
+					);
+				}
 			}
 			
 			// Add one for the common server


### PR DESCRIPTION
When running `apm publish` on a package with a dependency, I got this problem.

```
✓ Package content verified
⣻ Checking dependency: starling-source@2.7.0
D::ProcessQueue::UNHANDLED PROCESS ERROR IN com.apm.client.commands.packages.processes::PackageDependenciesVerifyProcess
E::ProcessQueue::Error #1009: Cannot access a property or method of a null object reference.
E::ProcessQueue::TypeError: Error #1009: Cannot access a property or method of a null object reference.
        at com.apm.client.repositories::PackageResolver/getPackageVersion()
        at com.apm.client.commands.packages.processes::PackageDependenciesVerifyProcess/start()
        at com.apm.client.processes::ProcessQueue/checkAndStartNextProcess()
        at com.apm.client.processes::ProcessQueue/process_eventHandler()
        at flash.events::EventDispatcher/dispatchEventFunction()
        at flash.events::EventDispatcher/dispatchEvent()
        at com.apm.client.processes::ProcessBase/complete()
        at Function/PackageRemoteContentVerifyProcess.as$0:anonymous()
        at com.apm.client.commands.packages.processes::PackageRemoteContentVerifyProcess/loader_statusHandler()
        at flash.events::EventDispatcher/dispatchEventFunction()
        at flash.events::EventDispatcher/dispatchEvent()
        at flash.net::URLLoader/redirectEvent()
ERROR :: Error #1009: Cannot access a property or method of a null object reference.
```

`PackageResolver` is used not in the context of a project, so APM.config.projectDefinition is null.