### PR TITLE
Improved hash code detection from certutil output on Windows server

### DIFF
--- a/client/src/com/apm/client/processes/generic/ChecksumWindowsProcess.as
+++ b/client/src/com/apm/client/processes/generic/ChecksumWindowsProcess.as
@@ -100,8 +100,7 @@ package com.apm.client.processes.generic
 		private function onOutputData( event:ProgressEvent ):void
 		{
 			var output:String = _process.standardOutput.readUTFBytes( _process.standardOutput.bytesAvailable );
-			var hashRegExp:RegExp = /^[A-Fa-f0-9]{64}$/m;
-			_data = hashRegExp.exec(output);
+			_data += output;
 		}
 		
 		
@@ -117,7 +116,8 @@ package com.apm.client.processes.generic
 //			APM.io.stopSpinner( event.exitCode == 0, " checksum calculated" );
 			if (event.exitCode == 0)
 			{
-				var checksum:String = _data;
+				var hashRegExp:RegExp = /^[A-Fa-f0-9]{64}$/m;
+				var checksum:String = hashRegExp.exec(_data);
 				complete( checksum );
 			}
 			else

--- a/client/src/com/apm/client/processes/generic/ChecksumWindowsProcess.as
+++ b/client/src/com/apm/client/processes/generic/ChecksumWindowsProcess.as
@@ -100,15 +100,8 @@ package com.apm.client.processes.generic
 		private function onOutputData( event:ProgressEvent ):void
 		{
 			var output:String = _process.standardOutput.readUTFBytes( _process.standardOutput.bytesAvailable );
-			var lines:Array = output.split( "\n" );
-			if (lines.length > 1)
-			{
-				_data = String(lines[1])
-						.replace( /\n/g, "" )
-						.replace( /\r/g, "" )
-						.replace( /\t/g, "" )
-						.replace( / /g, "" );
-			}
+			var hashRegExp:RegExp = /^[A-Fa-f0-9]{64}$/m;
+			_data = hashRegExp.exec(output);
 		}
 		
 		

--- a/client/src/com/apm/client/processes/generic/ExtractZipWindowsProcess.as
+++ b/client/src/com/apm/client/processes/generic/ExtractZipWindowsProcess.as
@@ -83,7 +83,7 @@ package com.apm.client.processes.generic
 				{
 					// Powershell script can't handle non-zip extension archives so we copy to a .zip tmp file and delete after
 					_zipFileRef = new File( _zipFile.nativePath + ".zip" );
-					_zipFile.copyTo( _zipFileRef, true );
+					_zipFile.copyTo( _zipFileRef );
 					_deleteAfter = true;
 				}
 				else

--- a/client/src/com/apm/client/processes/generic/ExtractZipWindowsProcess.as
+++ b/client/src/com/apm/client/processes/generic/ExtractZipWindowsProcess.as
@@ -83,7 +83,7 @@ package com.apm.client.processes.generic
 				{
 					// Powershell script can't handle non-zip extension archives so we copy to a .zip tmp file and delete after
 					_zipFileRef = new File( _zipFile.nativePath + ".zip" );
-					_zipFile.copyTo( _zipFileRef );
+					_zipFile.copyTo( _zipFileRef, true );
 					_deleteAfter = true;
 				}
 				else


### PR DESCRIPTION
`NativeProcess.standardOutputData` can be fired multiple times depending on the output buffer size. All output data now gets collected over time and hash gets only parsed if process finished successfully    

This patch improves the Sha256 hash code detection and fixes #149 for us.