### PR TITLE
Release v1.3.0

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,19 @@
+name: 'Close stale issues and PR'
+on:
+  schedule:
+    - cron: '30 1 * * 2'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-label: 'stale'
+          exempt-issue-labels: 'enhancement'
+          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          days-before-stale: 60
+          days-before-close: 5
+          days-before-pr-close: -1

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/stale@v4
         with:
           stale-issue-label: 'stale'
-          exempt-issue-labels: 'enhancement'
+          exempt-issue-labels: 'enhancement,bug,bug-air-sdk'
           stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'

--- a/client/apm.iml
+++ b/client/apm.iml
@@ -9,7 +9,7 @@
               <dependency linkage="Merged" />
             </entry>
           </entries>
-          <sdk name="current" />
+          <sdk name="AIRSDK_33.1.1" />
         </dependencies>
         <compiler-options>
           <option name="resourceFilesMode" value="None" />
@@ -18,7 +18,7 @@
         <packaging-air-desktop use-generated-descriptor="false" custom-descriptor-path="$MODULE_DIR$/src/apm.xml" package-file-name="apm-cli">
           <files-to-package>
             <FilePathAndPathInPackage file-path="$MODULE_DIR$/src/apm.bat" path-in-package="apm.bat" />
-            <FilePathAndPathInPackage file-path="$MODULE_DIR$/src/apm.sh" path-in-package="apm.sh" />
+            <FilePathAndPathInPackage file-path="$MODULE_DIR$/src/apm" path-in-package="apm" />
           </files-to-package>
         </packaging-air-desktop>
         <packaging-android />
@@ -33,7 +33,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
     </content>
-    <orderEntry type="jdk" jdkName="current" jdkType="Flex SDK Type (new)" />
+    <orderEntry type="jdk" jdkName="AIRSDK_33.1.1" jdkType="Flex SDK Type (new)" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module-library" exported="">
       <library type="flex">

--- a/client/src/com/apm/client/commands/packages/InstallCommand.as
+++ b/client/src/com/apm/client/commands/packages/InstallCommand.as
@@ -129,7 +129,7 @@ package com.apm.client.commands.packages
 			var lockFile:ProjectLock = APM.config.projectLock;
 
 			_installData = new InstallData();
-			_queue       = new ProcessQueue();
+			_queue = new ProcessQueue();
 
 			var packageIdentifierOrPath:String = null;
 			if (_parameters != null && _parameters.length > 0)
@@ -139,8 +139,7 @@ package com.apm.client.commands.packages
 				var version:String = (_parameters.length > 1) ? _parameters[1] : "latest";
 
 				// Check if ends in "airpackage"
-				if (packageIdentifierOrPath.indexOf( PackageFileUtils.AIRPACKAGEEXTENSION ) ==
-						packageIdentifierOrPath.length - PackageFileUtils.AIRPACKAGEEXTENSION.length)
+				if (PackageFileUtils.isAirPackagePath( packageIdentifierOrPath ))
 				{
 					// Install from a local air package file
 					var localPackageFile:File = FileUtils.getSourceForPath( packageIdentifierOrPath );

--- a/client/src/com/apm/client/commands/packages/OutdatedCommand.as
+++ b/client/src/com/apm/client/commands/packages/OutdatedCommand.as
@@ -29,7 +29,7 @@ package com.apm.client.commands.packages
 	import com.apm.data.packages.PackageDefinitionFile;
 	import com.apm.data.packages.PackageDependency;
 	import com.apm.data.project.ProjectDefinition;
-	import com.apm.utils.PackageCacheUtils;
+	import com.apm.utils.ProjectPackageCache;
 
 	import flash.events.EventDispatcher;
 
@@ -121,7 +121,7 @@ package com.apm.client.commands.packages
 
 		public function execute():void
 		{
-			var includeDependencies:Boolean      = false;
+			var includeDependencies:Boolean = false;
 			var printUpdateAvailableOnly:Boolean = true;
 			if (_parameters != null)
 			{
@@ -175,7 +175,7 @@ package com.apm.client.commands.packages
 						var hasUpdatesAvailable:Boolean = false;
 						for each (var packageData:InstallPackageData in _queryData.packagesToInstall)
 						{
-							var cachedPackage:PackageDefinitionFile = PackageCacheUtils.getCachedPackage( packageData.request.packageIdentifier );
+							var cachedPackage:PackageDefinitionFile = ProjectPackageCache.getPackage( packageData.request.packageIdentifier );
 
 							hasUpdatesAvailable ||= cachedPackage == null ? true : packageData.packageVersion.version.greaterThan(
 									cachedPackage.version.version );
@@ -192,7 +192,7 @@ package com.apm.client.commands.packages
 
 							for each (var packageData:InstallPackageData in _queryData.packagesToInstall)
 							{
-								var cachedPackage:PackageDefinitionFile = PackageCacheUtils.getCachedPackage(
+								var cachedPackage:PackageDefinitionFile = ProjectPackageCache.getPackage(
 										packageData.request.packageIdentifier );
 
 								var updateAvailable:Boolean = cachedPackage == null ? true : packageData.packageVersion.version.greaterThan(

--- a/client/src/com/apm/client/commands/packages/processes/InstallDeployProcess.as
+++ b/client/src/com/apm/client/commands/packages/processes/InstallDeployProcess.as
@@ -58,11 +58,11 @@ package com.apm.client.commands.packages.processes
 			super.start( completeCallback, failureCallback );
 			for each (var p:InstallPackageData in _installData.packagesToInstall)
 			{
-				var packageDir:File = PackageFileUtils.cacheDirForPackage( APM.config.packagesDirectory,
-																		   p.packageVersion.packageDef.identifier );
+				var packageDir:File = PackageFileUtils.contentsDirForPackage( APM.config.packagesDirectory,
+																			  p.packageVersion.packageDef.identifier );
 				if (packageDir == null || !packageDir.exists)
 				{
-					return failure( "Cache for package directory does not exist" );
+					return failure( "Contents directory for package does not exist" );
 				}
 				APM.io.showSpinner( "Deploying package: " + p.packageVersion.toStringWithIdentifier() );
 				for each (var ref:File in packageDir.getDirectoryListing())

--- a/client/src/com/apm/client/commands/packages/processes/InstallLocalPackageProcess.as
+++ b/client/src/com/apm/client/commands/packages/processes/InstallLocalPackageProcess.as
@@ -13,22 +13,15 @@
  */
 package com.apm.client.commands.packages.processes
 {
-	import com.apm.client.APM;
-	import com.apm.data.install.InstallData;
-	import com.apm.data.install.InstallRequest;
-	import com.apm.client.logging.Log;
-	import com.apm.client.repositories.PackageResolver;
 	import com.apm.client.processes.ProcessBase;
 	import com.apm.client.processes.ProcessQueue;
-	import com.apm.client.processes.generic.ExtractZipProcess;
+	import com.apm.data.install.InstallData;
+	import com.apm.data.install.InstallRequest;
 	import com.apm.data.packages.PackageDefinitionFile;
 	import com.apm.data.packages.PackageDependency;
-	import com.apm.data.packages.PackageVersion;
-	import com.apm.utils.PackageFileUtils;
-	
+
 	import flash.filesystem.File;
-	
-	
+
 	/**
 	 * This process is to request the package and assemble the listed dependencies
 	 */
@@ -37,23 +30,23 @@ package com.apm.client.commands.packages.processes
 		////////////////////////////////////////////////////////
 		//  CONSTANTS
 		//
-		
+
 		private static const TAG:String = "InstallQueryPackageProcess";
-		
-		
+
+
 		////////////////////////////////////////////////////////
 		//  VARIABLES
 		//
-		
+
 		private var _packageFile:File;
 		private var _installData:InstallData;
 		private var _failIfInstalled:Boolean;
-		
-		
+
+
 		////////////////////////////////////////////////////////
 		//  FUNCTIONALITY
 		//
-		
+
 		public function InstallLocalPackageProcess(
 				packageFile:File,
 				data:InstallData,
@@ -64,19 +57,20 @@ package com.apm.client.commands.packages.processes
 			_installData = data;
 			_failIfInstalled = failIfInstalled;
 		}
-		
-		
+
+
 		override public function start( completeCallback:Function = null, failureCallback:Function = null ):void
 		{
 			super.start( completeCallback, failureCallback );
-			
+
 			var packageDefinitionFile:PackageDefinitionFile = new PackageDefinitionFile();
 			var packageDir:File = new File();
-			
+
 			var subqueue:ProcessQueue = new ProcessQueue();
 			subqueue.addProcess( new PackageExtractDefinitionProcess( packageDefinitionFile, _packageFile ) );
 			subqueue.start(
-					function ():void {
+					function ():void
+					{
 						_installData.addPackage( packageDefinitionFile.version,
 												 new InstallRequest(
 														 packageDefinitionFile.packageDef.identifier,
@@ -87,7 +81,7 @@ package com.apm.client.commands.packages.processes
 														 _packageFile
 												 )
 						);
-						
+
 						// Queue dependencies for install
 						for each (var dep:PackageDependency in packageDefinitionFile.dependencies)
 						{
@@ -103,14 +97,15 @@ package com.apm.client.commands.packages.processes
 						}
 						complete();
 					},
-					function ( error:String ):void {
+					function ( error:String ):void
+					{
 						failure( error );
 					}
 			)
-			
+
 		}
-		
-		
+
+
 	}
-	
+
 }

--- a/client/src/com/apm/client/commands/packages/processes/UninstallFilesForPackageProcess.as
+++ b/client/src/com/apm/client/commands/packages/processes/UninstallFilesForPackageProcess.as
@@ -60,7 +60,7 @@ package com.apm.client.commands.packages.processes
 			super.start( completeCallback, failureCallback );
 			APM.io.showSpinner( "Removing package : " + _packageDefinition.packageDef.identifier );
 			
-			var cacheDir:File = PackageFileUtils.cacheDirForPackage( APM.config.packagesDirectory, _packageDefinition.packageDef.identifier );
+			var cacheDir:File = PackageFileUtils.contentsDirForPackage( APM.config.packagesDirectory, _packageDefinition.packageDef.identifier );
 			for each (var ref:File in cacheDir.getDirectoryListing())
 			{
 				if (ref.isDirectory)

--- a/client/src/com/apm/client/commands/packages/processes/UninstallPackageProcess.as
+++ b/client/src/com/apm/client/commands/packages/processes/UninstallPackageProcess.as
@@ -20,7 +20,7 @@ package com.apm.client.commands.packages.processes
 	import com.apm.client.processes.ProcessQueue;
 	import com.apm.data.packages.PackageDefinitionFile;
 	import com.apm.data.packages.PackageDependency;
-	import com.apm.utils.PackageCacheUtils;
+	import com.apm.utils.ProjectPackageCache;
 	import com.apm.utils.PackageFileUtils;
 
 	import flash.filesystem.File;
@@ -85,7 +85,7 @@ package com.apm.client.commands.packages.processes
 			super.start( completeCallback, failureCallback );
 
 			// Check the specified package is installed
-			if (!PackageCacheUtils.isPackageInstalled( _packageIdentifier, _version ))
+			if (!ProjectPackageCache.isPackageInstalled( _packageIdentifier, _version ))
 			{
 				if (_failIfNotInstalled)
 				{
@@ -107,15 +107,15 @@ package com.apm.client.commands.packages.processes
 			// Start uninstallation
 			APM.io.writeLine( "Uninstall package : " + _packageIdentifier );
 
-			var uninstallingPackageDir:File = PackageFileUtils.cacheDirForPackage( APM.config.packagesDirectory,
-																				   _packageIdentifier );
+			var uninstallingPackageDir:File = PackageFileUtils.contentsDirForPackage( APM.config.packagesDirectory,
+																					  _packageIdentifier );
 
 			var f:File = uninstallingPackageDir.resolvePath( PackageDefinitionFile.DEFAULT_FILENAME );
 
 			var uninstallingPackageDefinition:PackageDefinitionFile = new PackageDefinitionFile().load( f );
 
 			// need to determine if this package is required by another package currently installed
-			if (_checkIfRequiredDependency && PackageCacheUtils.isPackageRequiredDependency(
+			if (_checkIfRequiredDependency && ProjectPackageCache.isPackageRequiredDependency(
 					_uninstallingPackageIdentifier,
 					_packageIdentifier ))
 			{

--- a/client/src/com/apm/client/commands/project/processes/ApplicationDescriptorGenerationProcess.as
+++ b/client/src/com/apm/client/commands/project/processes/ApplicationDescriptorGenerationProcess.as
@@ -13,7 +13,6 @@
  */
 package com.apm.client.commands.project.processes
 {
-	import com.apm.SemVer;
 	import com.apm.client.APM;
 	import com.apm.client.logging.Log;
 	import com.apm.client.processes.ProcessBase;
@@ -21,48 +20,40 @@ package com.apm.client.commands.project.processes
 	import com.apm.data.packages.PackageDefinitionFile;
 	import com.apm.data.packages.PackageIdentifier;
 	import com.apm.data.project.ApplicationDescriptor;
-	import com.apm.data.project.ApplicationDescriptor;
-	import airsdk.AIRSDKVersion;
-	
-	import com.apm.data.project.ProjectLock;
 	import com.apm.utils.FileUtils;
 	import com.apm.utils.PackageCacheUtils;
-	
+
 	import flash.filesystem.File;
 	import flash.filesystem.FileMode;
 	import flash.filesystem.FileStream;
-	import flash.xml.XMLNode;
-	
-	
+
 	public class ApplicationDescriptorGenerationProcess extends ProcessBase
 	{
 		////////////////////////////////////////////////////////
 		//  CONSTANTS
 		//
-		
+
 		private static const TAG:String = "ApplicationDescriptorGenerationProcess";
-		
-		
-		
-		
+
+
 		////////////////////////////////////////////////////////
 		//  VARIABLES
 		//
-		
+
 		private var _appDescriptor:ApplicationDescriptor;
 		private var _outputPath:String;
-		
+
 		////////////////////////////////////////////////////////
 		//  FUNCTIONALITY
 		//
-		
+
 		public function ApplicationDescriptorGenerationProcess( appDescriptor:ApplicationDescriptor, outputPath:String )
 		{
 			_appDescriptor = appDescriptor;
-			_outputPath = outputPath;
+			_outputPath    = outputPath;
 		}
-		
-		
+
+
 		override public function start( completeCallback:Function = null, failureCallback:Function = null ):void
 		{
 			super.start( completeCallback, failureCallback );
@@ -72,12 +63,12 @@ package com.apm.client.commands.project.processes
 
 				//
 				//	LOAD TEMPLATE
-				
+
 				var configDescriptorPath:String = "application-descriptor.xml";
-				
-				var configDescriptor:File = new File( APM.config.configDirectory ).resolvePath( configDescriptorPath );
+
+				var configDescriptor:File    = new File( APM.config.configDirectory ).resolvePath( configDescriptorPath );
 				var specifiedDescriptor:File = FileUtils.getSourceForPath( _outputPath );
-				
+
 				if (configDescriptor.exists)
 				{
 					Log.d( TAG, "Loading " + configDescriptorPath );
@@ -96,18 +87,18 @@ package com.apm.client.commands.project.processes
 						Log.l( TAG, _appDescriptor.validate() );
 					}
 				}
-				
+
 				// Check if the loaded descriptor is valid, otherwise use the template
 				if (!_appDescriptor.isValid())
 				{
 					Log.d( TAG, "Loading application descriptor template" );
 					_appDescriptor.loadString( ApplicationDescriptor.APPLICATION_DESCRIPTOR_TEMPLATE );
 				}
-				
-				_appDescriptor.updateFromProjectDefinition( APM.config.projectDefinition );
+
+				_appDescriptor.updateFromProjectDefinition( APM.config.projectDefinition, APM.config.buildType );
 				_appDescriptor.updateAndroidAdditions();
 				_appDescriptor.updateIOSAdditions();
-				
+
 				if (APM.config.projectLock != null)
 				{
 					for each (var packageIdentifier:String in APM.config.projectLock.uninstalledPackageIdentifiers)
@@ -117,7 +108,7 @@ package com.apm.client.commands.project.processes
 						);
 					}
 				}
-				
+
 				for each (var packageDefinition:PackageDefinitionFile in PackageCacheUtils.getCachedPackages())
 				{
 					if (packageDefinition.packageDef.type == PackageDefinition.TYPE_ANE)
@@ -127,9 +118,9 @@ package com.apm.client.commands.project.processes
 						);
 					}
 				}
-			
+
 				_appDescriptor.save( specifiedDescriptor );
-				
+
 				APM.io.stopSpinner( true, "App descriptor generated: " + specifiedDescriptor.nativePath );
 				complete();
 			}
@@ -140,8 +131,8 @@ package com.apm.client.commands.project.processes
 				failure( e.message );
 			}
 		}
-		
-		
+
+
 		private function writeApplicationTemplate( file:File ):void
 		{
 			var fs:FileStream = new FileStream();
@@ -149,8 +140,8 @@ package com.apm.client.commands.project.processes
 			fs.writeUTFBytes( ApplicationDescriptor.APPLICATION_DESCRIPTOR_TEMPLATE.toString() );
 			fs.close();
 		}
-		
-		
+
+
 	}
-	
+
 }

--- a/client/src/com/apm/client/commands/project/processes/ApplicationDescriptorGenerationProcess.as
+++ b/client/src/com/apm/client/commands/project/processes/ApplicationDescriptorGenerationProcess.as
@@ -21,7 +21,7 @@ package com.apm.client.commands.project.processes
 	import com.apm.data.packages.PackageIdentifier;
 	import com.apm.data.project.ApplicationDescriptor;
 	import com.apm.utils.FileUtils;
-	import com.apm.utils.PackageCacheUtils;
+	import com.apm.utils.ProjectPackageCache;
 
 	import flash.filesystem.File;
 	import flash.filesystem.FileMode;
@@ -109,7 +109,7 @@ package com.apm.client.commands.project.processes
 					}
 				}
 
-				for each (var packageDefinition:PackageDefinitionFile in PackageCacheUtils.getCachedPackages())
+				for each (var packageDefinition:PackageDefinitionFile in ProjectPackageCache.getPackages())
 				{
 					if (packageDefinition.packageDef.type == PackageDefinition.TYPE_ANE)
 					{

--- a/client/src/com/apm/client/commands/project/processes/IOSAdditionsMergeMacOSRunProcess.as
+++ b/client/src/com/apm/client/commands/project/processes/IOSAdditionsMergeMacOSRunProcess.as
@@ -30,8 +30,11 @@ package com.apm.client.commands.project.processes
 	
 	
 	/**
+	 * THIS PROCESS IS STILL IN DEVELOPMENT
+	 *
 	 * Takes 2 plist files and merges them with the PlistBuddy utility on macOS
 	 * <br/>
+	 *
 	 *
 	 * We use PListBuddy here
 	 *

--- a/client/src/com/apm/client/commands/project/processes/IOSAdditionsMergeProcess.as
+++ b/client/src/com/apm/client/commands/project/processes/IOSAdditionsMergeProcess.as
@@ -72,7 +72,10 @@ package com.apm.client.commands.project.processes
 					var regex:RegExp = new RegExp( "\\$\\{" + param.name + "\\}", "g" );
 					infoAdditionsProjectContent = infoAdditionsProjectContent.replace( regex, param.value );
 				}
-				infoAdditionsProjectContent = infoAdditionsProjectContent.replace( /\$\{applicationId\}/g, APM.config.projectDefinition.applicationId );
+				infoAdditionsProjectContent = infoAdditionsProjectContent.replace(
+						/\$\{applicationId\}/g,
+						APM.config.projectDefinition.getApplicationId( APM.config.buildType )
+				);
 				
 				FileUtils.writeStringAsFileContent( infoAdditionsFile, infoAdditionsProjectContent );
 			}

--- a/client/src/com/apm/client/commands/project/processes/IOSEntitlementsMergeProcess.as
+++ b/client/src/com/apm/client/commands/project/processes/IOSEntitlementsMergeProcess.as
@@ -73,7 +73,10 @@ package com.apm.client.commands.project.processes
 					var regex:RegExp = new RegExp( "\\$\\{" + param.name + "\\}", "g" );
 					entitlementsProjectContent = entitlementsProjectContent.replace( regex, param.value );
 				}
-				entitlementsProjectContent = entitlementsProjectContent.replace( /\$\{applicationId\}/g, APM.config.projectDefinition.applicationId );
+				entitlementsProjectContent = entitlementsProjectContent.replace(
+						/\$\{applicationId\}/g,
+						APM.config.projectDefinition.getApplicationId( APM.config.buildType )
+				);
 				
 				FileUtils.writeStringAsFileContent( entitlementsFile, entitlementsProjectContent );
 			}

--- a/client/src/com/apm/client/commands/project/processes/IOSPlistMergeProcess.as
+++ b/client/src/com/apm/client/commands/project/processes/IOSPlistMergeProcess.as
@@ -72,7 +72,10 @@ package com.apm.client.commands.project.processes
 					mergeContent = mergeContent.replace( regex, param.value );
 				}
 				
-				mergeContent = mergeContent.replace( /\$\{applicationId\}/g, APM.config.projectDefinition.applicationId );
+				mergeContent = mergeContent.replace(
+						/\$\{applicationId\}/g,
+						APM.config.projectDefinition.getApplicationId( APM.config.buildType )
+				);
 				
 				// Load and merge plists
 				var merge:Plist = new Plist( mergeContent );

--- a/client/src/com/apm/client/commands/project/processes/ProjectConfigDescribeProcess.as
+++ b/client/src/com/apm/client/commands/project/processes/ProjectConfigDescribeProcess.as
@@ -21,7 +21,7 @@ package com.apm.client.commands.project.processes
 	import com.apm.data.packages.PackageParameter;
 	import com.apm.data.project.ProjectDefinition;
 	import com.apm.data.project.ProjectParameter;
-	import com.apm.utils.PackageCacheUtils;
+	import com.apm.utils.ProjectPackageCache;
 	
 	import flash.html.script.Package;
 	
@@ -76,7 +76,7 @@ package com.apm.client.commands.project.processes
 			
 			
 			var param:ProjectParameter = project.getConfigurationParam( _paramName, APM.config.buildType );
-			var paramPackage:PackageDefinitionFile = PackageCacheUtils.getCachedPackage( _paramName );
+			var paramPackage:PackageDefinitionFile = ProjectPackageCache.getPackage( _paramName );
 			
 			if (param != null)
 			{
@@ -103,7 +103,7 @@ package com.apm.client.commands.project.processes
 			var linePrefix:String = "# ";
 			var linePadding:String = "        ";
 			
-			var packages:Vector.<PackageDefinitionFile> = PackageCacheUtils.getCachedPackages();
+			var packages:Vector.<PackageDefinitionFile> = ProjectPackageCache.getPackages();
 			var descriptions:Array = [];
 			for each (var packageDef:PackageDefinitionFile in packages)
 			{

--- a/client/src/com/apm/client/commands/project/processes/ProjectConfigSetProcess.as
+++ b/client/src/com/apm/client/commands/project/processes/ProjectConfigSetProcess.as
@@ -19,7 +19,7 @@ package com.apm.client.commands.project.processes
 	import com.apm.data.packages.PackageParameter;
 	import com.apm.data.project.ProjectDefinition;
 	import com.apm.data.project.ProjectParameter;
-	import com.apm.utils.PackageCacheUtils;
+	import com.apm.utils.ProjectPackageCache;
 	
 	
 	public class ProjectConfigSetProcess extends ProcessBase
@@ -73,7 +73,7 @@ package com.apm.client.commands.project.processes
 			else if (_paramValue == null)
 			{
 				var param:ProjectParameter = project.getConfigurationParam( _paramName, APM.config.buildType );
-				var paramPackage:PackageDefinitionFile = PackageCacheUtils.getCachedPackage( _paramName );
+				var paramPackage:PackageDefinitionFile = ProjectPackageCache.getPackage( _paramName );
 				
 				if (param != null)
 				{

--- a/client/src/com/apm/client/commands/project/processes/ValidatePackageCacheProcess.as
+++ b/client/src/com/apm/client/commands/project/processes/ValidatePackageCacheProcess.as
@@ -17,7 +17,7 @@ package com.apm.client.commands.project.processes
 	import com.apm.client.logging.Log;
 	import com.apm.client.processes.ProcessBase;
 	import com.apm.data.project.ProjectDefinition;
-	import com.apm.utils.PackageCacheUtils;
+	import com.apm.utils.ProjectPackageCache;
 	
 	import flash.filesystem.File;
 	
@@ -65,7 +65,7 @@ package com.apm.client.commands.project.processes
 			var packagesDir:File = new File( APM.config.packagesDirectory );
 			for (var i:int = 0; i < project.dependencies.length; i++)
 			{
-				if (!PackageCacheUtils.isPackageInstalled(
+				if (!ProjectPackageCache.isPackageInstalled(
 						project.dependencies[ i ].identifier,
 						project.dependencies[ i ].version
 				))

--- a/client/src/com/apm/client/commands/project/processes/data/AndroidManifestDefault.xml
+++ b/client/src/com/apm/client/commands/project/processes/data/AndroidManifestDefault.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="30" />
+    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="33" />
 
     <application>
 

--- a/client/src/com/apm/client/commands/project/processes/data/InfoAdditionsDefault.xml
+++ b/client/src/com/apm/client/commands/project/processes/data/InfoAdditionsDefault.xml
@@ -8,7 +8,7 @@
         </array>
 
         <key>MinimumOSVersion</key>
-        <string>10.0</string>
+        <string>11.0</string>
 
         <!--
         <key>UILaunchStoryboardName</key>

--- a/client/src/com/apm/client/config/RunConfig.as
+++ b/client/src/com/apm/client/config/RunConfig.as
@@ -27,7 +27,7 @@ package com.apm.client.config
 	import com.apm.data.project.ProjectLock;
 	import com.apm.data.user.UserSettings;
 	import com.apm.utils.DeployFileUtils;
-	import com.apm.utils.PackageCacheUtils;
+	import com.apm.utils.ProjectPackageCache;
 	
 	import flash.filesystem.File;
 	import flash.system.Capabilities;
@@ -123,8 +123,8 @@ package com.apm.client.config
 		 */
 		public function get airDirectory():String { return _airDirectory; }
 		public function set airDirectory( value:String):void { _airDirectory = value; }
-		
-		
+
+
 		private var _uname:String = null;
 		/**
 		 * The unix name of the current terminal
@@ -195,13 +195,13 @@ package com.apm.client.config
 		{
 			var deployPackageCacheDir:File = DeployFileUtils.getDeployLocation(
 					this,
-					PackageCacheUtils.PACKAGE_CACHE_DIR
+					ProjectPackageCache.PACKAGE_CACHE_DIR
 			);
 			if (deployPackageCacheDir != null)
 			{
 				return deployPackageCacheDir.nativePath;
 			}
-			return workingDirectory + File.separator + PackageCacheUtils.PACKAGE_CACHE_DIR;
+			return workingDirectory + File.separator + ProjectPackageCache.PACKAGE_CACHE_DIR;
 		}
 		
 		
@@ -243,8 +243,30 @@ package com.apm.client.config
 				return File.userDirectory.nativePath;
 			}
 		}
-		
-		
+
+
+		/**
+		 * The path to the user's ".airsdk" directory for air sdk user config and cache
+		 */
+		public function get airSdkUserDirectory():File
+		{
+			var airSdkDir:File = new File( homeDirectory + File.separator + ".airsdk" );
+			if (!airSdkDir.exists) airSdkDir.createDirectory();
+			return airSdkDir;
+		}
+
+
+		/**
+		 * The path to the user's ".airsdk" cache directory
+		 */
+		public function get airSdkCacheDirectory():File
+		{
+			var airSdkCacheDir:File = airSdkUserDirectory.resolvePath( "cache" );
+			if (!airSdkCacheDir.exists) airSdkCacheDir.createDirectory();
+			return airSdkCacheDir;
+		}
+
+
 		/**
 		 * Attempts to find a java executable in the system.
 		 *

--- a/client/src/com/apm/client/processes/generic/ChecksumWindowsProcess.as
+++ b/client/src/com/apm/client/processes/generic/ChecksumWindowsProcess.as
@@ -100,15 +100,7 @@ package com.apm.client.processes.generic
 		private function onOutputData( event:ProgressEvent ):void
 		{
 			var output:String = _process.standardOutput.readUTFBytes( _process.standardOutput.bytesAvailable );
-			var lines:Array = output.split( "\n" );
-			if (lines.length > 1)
-			{
-				_data = String(lines[1])
-						.replace( /\n/g, "" )
-						.replace( /\r/g, "" )
-						.replace( /\t/g, "" )
-						.replace( / /g, "" );
-			}
+			_data += output;
 		}
 		
 		
@@ -124,7 +116,8 @@ package com.apm.client.processes.generic
 //			APM.io.stopSpinner( event.exitCode == 0, " checksum calculated" );
 			if (event.exitCode == 0)
 			{
-				var checksum:String = _data;
+				var hashRegExp:RegExp = /^[A-Fa-f0-9]{64}$/m;
+				var checksum:String = hashRegExp.exec(_data);
 				complete( checksum );
 			}
 			else

--- a/client/src/com/apm/client/processes/generic/ExtractZipWindowsProcess.as
+++ b/client/src/com/apm/client/processes/generic/ExtractZipWindowsProcess.as
@@ -83,7 +83,7 @@ package com.apm.client.processes.generic
 				{
 					// Powershell script can't handle non-zip extension archives so we copy to a .zip tmp file and delete after
 					_zipFileRef = new File( _zipFile.nativePath + ".zip" );
-					_zipFile.copyTo( _zipFileRef );
+					_zipFile.copyTo( _zipFileRef, true );
 					_deleteAfter = true;
 				}
 				else

--- a/client/src/com/apm/data/project/ApplicationDescriptor.as
+++ b/client/src/com/apm/data/project/ApplicationDescriptor.as
@@ -120,13 +120,13 @@ package com.apm.data.project
 		}
 		
 		
-		public function updateFromProjectDefinition( project:ProjectDefinition ):void
+		public function updateFromProjectDefinition( project:ProjectDefinition, buildType:String=null ):void
 		{
 			if (_xml != null)
 			{
 				default xml namespace = _airNS;
 				
-				if (isPropertyValueValid( project.applicationId )) _xml.id = project.applicationId;
+				if (isPropertyValueValid( project.getApplicationId( buildType ) )) _xml.id = project.getApplicationId( buildType );
 				if (isPropertyValueValid( project.applicationName ))
 				{
 					if (project.applicationName is String)

--- a/client/src/com/apm/data/project/ProjectBuildType.as
+++ b/client/src/com/apm/data/project/ProjectBuildType.as
@@ -33,7 +33,10 @@ package com.apm.data.project
 		 * The name of this build type eg debug
 		 */
 		public var name:String;
-		
+
+
+		public var applicationId:String = null;
+
 		
 		private var _configuration:Vector.<ProjectParameter>;
 		
@@ -53,6 +56,11 @@ package com.apm.data.project
 		{
 			if (data != null)
 			{
+				if (data.hasOwnProperty("identifier"))
+				{
+					applicationId = data.identifier;
+				}
+
 				if (data.hasOwnProperty( "configuration" ))
 				{
 					_configuration = new Vector.<ProjectParameter>();
@@ -72,14 +80,19 @@ package com.apm.data.project
 		public function toObject():Object
 		{
 			var data:Object = {};
-			
+
+			if (applicationId != null)
+			{
+				data["identifier"] = applicationId;
+			}
+
 			var configObject:Object = {};
 			for each (var param:ProjectParameter in _configuration)
 			{
 				configObject[ param.name ] = param.toObject( true );
 			}
 			data[ "configuration" ] = configObject;
-			
+
 			return data;
 		}
 		
@@ -112,6 +125,12 @@ package com.apm.data.project
 		 */
 		public function setConfigurationParamValue( key:String, value:String ):void
 		{
+			if (key == "applicationId")
+			{
+				applicationId = value;
+				return;
+			}
+
 			if (_configuration == null) _configuration = new <ProjectParameter>[];
 			var param:ProjectParameter = getConfigurationParam( key );
 			if (param == null)

--- a/client/src/com/apm/data/project/ProjectDefinition.as
+++ b/client/src/com/apm/data/project/ProjectDefinition.as
@@ -237,7 +237,23 @@ package com.apm.data.project
 		//	CONFIGURATION PARAMETERS
 		//
 
-//		public function get configuration():Vector.<ProjectParameter> { return _configuration; }
+
+		public function getApplicationId( buildType:String ):String
+		{
+			if (buildType != null)
+			{
+				var projectBuildType:ProjectBuildType = getBuildType( buildType );
+				if (projectBuildType != null)
+				{
+					if (projectBuildType.applicationId != null)
+					{
+						return projectBuildType.applicationId;
+					}
+				}
+			}
+			return applicationId;
+		}
+
 
 		/**
 		 * Retrieves the configuration parameters for the specified build type

--- a/client/src/com/apm/data/user/PackageCache.as
+++ b/client/src/com/apm/data/user/PackageCache.as
@@ -1,0 +1,184 @@
+/**
+ *        __       __               __
+ *   ____/ /_ ____/ /______ _ ___  / /_
+ *  / __  / / ___/ __/ ___/ / __ `/ __/
+ * / /_/ / (__  ) / / /  / / /_/ / /
+ * \__,_/_/____/_/ /_/  /_/\__, /_/
+ *                           / /
+ *                           \/
+ * https://distriqt.com
+ *
+ * @author 		Michael Archbold (https://github.com/marchbold)
+ * @created		7/12/2022
+ * @copyright	distriqt 2022 (https://distriqt.com/copyright/license.txt)
+ */
+package com.apm.data.user
+{
+	import com.apm.data.packages.PackageVersion;
+	import com.apm.utils.PackageFileUtils;
+
+	import flash.events.Event;
+	import flash.events.IOErrorEvent;
+
+	import flash.filesystem.File;
+
+	/**
+	 * Represents the user air package cache.
+	 * <br/>
+	 * This is a location in the user's directory where we store downloaded airpackages
+	 * for easy installation across projects to avoid multiple downloads.
+	 */
+	public class PackageCache
+	{
+		////////////////////////////////////////////////////////
+		//	CONSTANTS
+		//
+
+		private static const TAG:String = "PackageCache";
+
+
+		public static const PACKAGE_CACHE_DIR:String = "airpackages";
+
+
+		////////////////////////////////////////////////////////
+		//	VARIABLES
+		//
+
+		private var _packageCacheDir:File;
+
+
+		////////////////////////////////////////////////////////
+		//	FUNCTIONALITY
+		//
+
+		/**
+		 * Constructor
+		 *
+		 * @param airSdkCacheDir This should be the cache directory which contains the "airpackages" directory eg ~/.airsdk/cache
+		 */
+		public function PackageCache( airSdkCacheDir:File )
+		{
+			var packageCacheDir:File = airSdkCacheDir.resolvePath( PackageCache.PACKAGE_CACHE_DIR );
+			if (!packageCacheDir.exists) packageCacheDir.createDirectory();
+
+			_packageCacheDir = packageCacheDir;
+		}
+
+
+		/**
+		 *
+		 * @param airpackage
+		 * @return
+		 */
+		public function hasPackage( airpackage:PackageVersion ):Boolean
+		{
+			return getPackageFile(airpackage).exists;
+		}
+
+
+		/**
+		 * Retrieve the File reference for the airpackage in the package cache
+		 *
+		 * @param airpackage
+		 *
+		 * @return File reference for the airpackage
+		 */
+		public function getPackageFile( airpackage:PackageVersion ):File
+		{
+			return PackageFileUtils.fileForPackage(
+					_packageCacheDir.nativePath,
+					airpackage );
+		}
+
+
+		/**
+		 * Retrieves an airpackage from the cache, copying it to the specified location.
+		 *
+		 * @param airpackage
+		 * @param dest
+		 * @param callback
+		 */
+		public function copyPackageFile( airpackage:PackageVersion, dest:File, callback:Function ):void
+		{
+			if (hasPackage(airpackage))
+			{
+				var cachePackage:File = getPackageFile( airpackage );
+				copyToAsync( cachePackage, dest, callback );
+			}
+			else
+			{
+				callback( false );
+			}
+		}
+
+
+		/**
+		 * Adds a package to the cache.
+		 *
+		 * Copies the file to the appropriate location and replaces any existing file in that cache
+		 *
+		 * @param airpackage
+		 * @param file
+		 * @param callback
+		 */
+		public function putPackageFile( airpackage:PackageVersion, file:File, callback:Function ):void
+		{
+			cacheDirectoryForPackage(airpackage.packageDef.identifier)
+					.createDirectory();
+
+			var cacheLocation:File = getPackageFile( airpackage );
+			copyToAsync( file, cacheLocation, callback );
+		}
+
+
+		////////////////////////////////////////////////////////
+		//	INTERNALS
+		//
+
+		private function cacheDirectoryForPackage( identifier:String ):File
+		{
+			return PackageFileUtils.directoryForPackage(
+					_packageCacheDir.nativePath,
+					identifier
+			);
+		}
+
+
+		private function copyToAsync( source:File, dest:File, callback:Function ):void
+		{
+			if (source != null && source.exists)
+			{
+				var completeHandler:Function = function( event:Event ):void
+				{
+					event.currentTarget.removeEventListener( Event.COMPLETE, completeHandler );
+					event.currentTarget.removeEventListener( IOErrorEvent.IO_ERROR, errorHandler );
+
+					callback( true );
+				};
+
+				var errorHandler:Function = function( event:Event ):void
+				{
+					event.currentTarget.removeEventListener( Event.COMPLETE, completeHandler );
+					event.currentTarget.removeEventListener( IOErrorEvent.IO_ERROR, errorHandler );
+
+					callback( false );
+				};
+
+				source.addEventListener( Event.COMPLETE, completeHandler );
+				source.addEventListener( IOErrorEvent.IO_ERROR, errorHandler );
+				source.copyToAsync( dest, true );
+			}
+			else
+			{
+				callback( false );
+			}
+		}
+
+
+
+		////////////////////////////////////////////////////////
+		//	EVENT HANDLERS
+		//
+
+	}
+}

--- a/client/src/com/apm/utils/DeployFileUtils.as
+++ b/client/src/com/apm/utils/DeployFileUtils.as
@@ -51,7 +51,7 @@ package com.apm.utils
 			DEPLOY_OPTIONS[ PackageFileUtils.AIRPACKAGE_SWC_DIR ] = "swcDir";
 			DEPLOY_OPTIONS[ PackageFileUtils.AIRPACKAGE_SRC_DIR ] = "srcDir";
 			DEPLOY_OPTIONS[ PackageFileUtils.AIRPACKAGE_ASSETS ] = "assetsDir";
-			DEPLOY_OPTIONS[ PackageCacheUtils.PACKAGE_CACHE_DIR ] = "packageCacheDir";
+			DEPLOY_OPTIONS[ ProjectPackageCache.PACKAGE_CACHE_DIR ] = "packageCacheDir";
 			DEPLOY_OPTIONS[ "config" ] = "configDir";
 		}
 		
@@ -63,7 +63,7 @@ package com.apm.utils
 			DEFAULT_DIRS[ PackageFileUtils.AIRPACKAGE_SWC_DIR ] = "libs";
 			DEFAULT_DIRS[ PackageFileUtils.AIRPACKAGE_SRC_DIR ] = "libs_src";
 			DEFAULT_DIRS[ PackageFileUtils.AIRPACKAGE_ASSETS ] = "assets";
-			DEFAULT_DIRS[ PackageCacheUtils.PACKAGE_CACHE_DIR ] = PackageCacheUtils.PACKAGE_CACHE_DIR;
+			DEFAULT_DIRS[ ProjectPackageCache.PACKAGE_CACHE_DIR ] = ProjectPackageCache.PACKAGE_CACHE_DIR;
 			DEFAULT_DIRS[ "config" ] = "config";
 		}
 		
@@ -86,7 +86,7 @@ package com.apm.utils
 					case PackageFileUtils.AIRPACKAGE_SWC_DIR:
 					case PackageFileUtils.AIRPACKAGE_SRC_DIR:
 					case PackageFileUtils.AIRPACKAGE_ASSETS:
-					case PackageCacheUtils.PACKAGE_CACHE_DIR:
+					case ProjectPackageCache.PACKAGE_CACHE_DIR:
 					case "config":
 						deployDirForType = working.resolvePath( DEFAULT_DIRS[ dirName ] );
 						break;

--- a/client/src/com/apm/utils/FileUtils.as
+++ b/client/src/com/apm/utils/FileUtils.as
@@ -15,38 +15,37 @@ package com.apm.utils
 {
 	import com.apm.client.APM;
 	import com.apm.client.logging.Log;
-	
+
 	import flash.filesystem.File;
 	import flash.filesystem.FileMode;
 	import flash.filesystem.FileStream;
-	
-	
+
 	public class FileUtils
 	{
 		////////////////////////////////////////////////////////
 		//  CONSTANTS
 		//
-		
+
 		private static const TAG:String = "FileUtils";
-		
-		
+
+
 		////////////////////////////////////////////////////////
 		//  VARIABLES
 		//
-		
-		
+
+
 		private static var _tmpDirName:String;
-		
-		
+
+
 		////////////////////////////////////////////////////////
 		//  FUNCTIONALITY
 		//
-		
+
 		public function FileUtils()
 		{
 		}
-		
-		
+
+
 		/**
 		 * Returns a global location for files stored / downloaded / used by the client
 		 */
@@ -54,8 +53,8 @@ package com.apm.utils
 		{
 			return File.applicationStorageDirectory;
 		}
-		
-		
+
+
 		/**
 		 * Returns a global location for utilities used by the client
 		 */
@@ -63,8 +62,8 @@ package com.apm.utils
 		{
 			return appStorageDirectory.resolvePath( "tools" );
 		}
-		
-		
+
+
 		/**
 		 * Returns a global location for utilities used by the client
 		 */
@@ -75,8 +74,8 @@ package com.apm.utils
 //			if (!tmpDir.exists) tmpDir.createDirectory();
 			return tmpDir;
 		}
-		
-		
+
+
 		/**
 		 * Finds all files in a directory and subdirectores with the specified name
 		 * - lists the files before the directories.
@@ -111,8 +110,8 @@ package com.apm.utils
 			}
 			return files;
 		}
-		
-		
+
+
 		public static function countFiles( directory:File ):int
 		{
 			var count:int = 0;
@@ -129,8 +128,8 @@ package com.apm.utils
 			}
 			return count;
 		}
-		
-		
+
+
 		public static function countFilesByType( directory:File, type:String ):int
 		{
 			var count:int = 0;
@@ -147,12 +146,12 @@ package com.apm.utils
 			}
 			return count;
 		}
-		
-		
+
+
 		public static function copyDirectoryTo( src:File, dest:File, overwrite:Boolean = false ):void
 		{
 			if (!dest.exists) dest.createDirectory();
-			
+
 			var directory:Array = src.getDirectoryListing();
 			for each (var f:File in directory)
 			{
@@ -162,8 +161,8 @@ package com.apm.utils
 					f.copyTo( dest.resolvePath( f.name ), overwrite );
 			}
 		}
-		
-		
+
+
 		public static function removeEmptyDirectories( directory:File, recurse:Boolean = false ):void
 		{
 			if (directory != null && directory.exists)
@@ -191,8 +190,8 @@ package com.apm.utils
 				}
 			}
 		}
-		
-		
+
+
 		public static function readFileContentAsString( file:File ):String
 		{
 			var fs:FileStream = new FileStream();
@@ -201,8 +200,8 @@ package com.apm.utils
 			fs.close();
 			return content;
 		}
-		
-		
+
+
 		public static function writeStringAsFileContent( file:File, content:String ):void
 		{
 			var fileStream:FileStream = new FileStream();
@@ -210,8 +209,8 @@ package com.apm.utils
 			fileStream.writeUTFBytes( content );
 			fileStream.close();
 		}
-		
-		
+
+
 		/**
 		 * Determines the File reference specified by path by checking it as an
 		 * absolute path and then a relative path to the working directory.
@@ -235,7 +234,22 @@ package com.apm.utils
 			}
 			return new File( APM.config.workingDirectory + File.separator + path );
 		}
-		
+
+
+		/**
+		 * Extracts the extension of a file path
+		 *
+		 * @param path
+		 *
+		 * @return
+		 */
+		public static function getExtension( path:String ):String
+		{
+			var extension:String = path.substring( path.lastIndexOf( "." ) + 1 );
+			return extension.toLowerCase();
+		}
+
+
 	}
-	
+
 }

--- a/client/src/com/apm/utils/PackageFileUtils.as
+++ b/client/src/com/apm/utils/PackageFileUtils.as
@@ -17,97 +17,114 @@ package com.apm.utils
 {
 	import com.apm.SemVer;
 	import com.apm.data.packages.PackageVersion;
-	
+
 	import flash.filesystem.File;
-	
-	
+
 	public class PackageFileUtils
 	{
 		////////////////////////////////////////////////////////
 		//  CONSTANTS
 		//
-		
+
 		private static const TAG:String = "PackageFileUtils";
-		
+
 		public static const AIRPACKAGEEXTENSION:String = "airpackage";
-		
-		
+
+
 		public static const AIRPACKAGE_SWC_DIR:String = "swc";
 		public static const AIRPACKAGE_ANE_DIR:String = "ane";
 		public static const AIRPACKAGE_SRC_DIR:String = "src";
-		
+
 		public static const AIRPACKAGE_ASSETS:String = "assets";
 		public static const AIRPACKAGE_PLATFORMS:String = "platforms";
-		
-		
+
+
 		////////////////////////////////////////////////////////
 		//  VARIABLES
 		//
-		
-		
+
+
 		////////////////////////////////////////////////////////
 		//  FUNCTIONALITY
 		//
-		
+
 		public function PackageFileUtils()
 		{
 		}
-		
-		
+
+
 		public static function directoryForPackage( packagesDir:String, identifier:String ):File
 		{
 			var packageDir:File = new File( packagesDir + File.separator + identifier );
 			return packageDir;
 		}
-		
-		
+
+
 		public static function filenameForPackage( packageVersion:PackageVersion ):String
 		{
 			var filename:String = packageVersion.packageDef.identifier + "_" + packageVersion.version.toString() + "." + AIRPACKAGEEXTENSION;
 			return filename;
 		}
-		
-		
-		
+
+
 		public static function fileForPackage( packagesDir:String, packageVersion:PackageVersion ):File
 		{
-			return PackageFileUtils.directoryForPackage( packagesDir, packageVersion.packageDef.identifier )
+			return directoryForPackage( packagesDir, packageVersion.packageDef.identifier )
 					.resolvePath(
 							PackageFileUtils.filenameForPackage( packageVersion )
 					);
 		}
-		
-		
-		public static function cacheDirForPackage( packagesDir:String, identifier:String ):File
-		{
-			return PackageFileUtils.directoryForPackage( packagesDir, identifier )
-					.resolvePath( cacheDirName() );
-		}
-		
-		
-		public static function cacheDirName():String
-		{
-			return "contents";
-		}
-		
-		
-		
-		
+
+
 		public static function fileForPackageFromIdentifierVersion( packagesDir:String, identifier:String, version:SemVer ):File
 		{
-			return PackageFileUtils.directoryForPackage( packagesDir, identifier )
+			return directoryForPackage( packagesDir, identifier )
 					.resolvePath(
-							PackageFileUtils.filenameForPackageFromIdentifierVersion( identifier, version )
+							filenameForPackageFromIdentifierVersion( identifier, version )
 					);
 		}
-		
-		
+
+
 		public static function filenameForPackageFromIdentifierVersion( identifier:String, version:SemVer ):String
 		{
 			var filename:String = identifier + "_" + version.toString() + "." + AIRPACKAGEEXTENSION;
 			return filename;
 		}
-		
+
+
+		//
+		//	LOCAL CONTENTS
+		//
+
+
+		/**
+		 * Extracted package location for access to package contents
+		 *
+		 * @param packagesDir
+		 * @param identifier
+		 * @return
+		 */
+		public static function contentsDirForPackage( packagesDir:String, identifier:String ):File
+		{
+			return directoryForPackage( packagesDir, identifier )
+					.resolvePath( contentsDirName() );
+		}
+
+
+		/**
+		 * Name of directory to use to extract the contents of a package
+		 *
+		 * @return
+		 */
+		public static function contentsDirName():String
+		{
+			return "contents";
+		}
+
+
+
+
+
 	}
-	
+
 }

--- a/client/src/com/apm/utils/PackageFileUtils.as
+++ b/client/src/com/apm/utils/PackageFileUtils.as
@@ -92,6 +92,22 @@ package com.apm.utils
 		}
 
 
+		/**
+		 *
+		 * @param packageIdentifierOrPath
+		 * @return
+		 */
+		public static function isAirPackagePath( packageIdentifierOrPath:String ):Boolean
+		{
+			if (packageIdentifierOrPath.indexOf( PackageFileUtils.AIRPACKAGEEXTENSION ) > 0)
+			{
+				var extension:String = FileUtils.getExtension( packageIdentifierOrPath );
+				return extension == PackageFileUtils.AIRPACKAGEEXTENSION;
+			}
+			return false;
+		}
+
+
 		//
 		//	LOCAL CONTENTS
 		//
@@ -120,9 +136,6 @@ package com.apm.utils
 		{
 			return "contents";
 		}
-
-
-
 
 
 	}

--- a/client/src/com/apm/utils/ProjectPackageCache.as
+++ b/client/src/com/apm/utils/ProjectPackageCache.as
@@ -19,41 +19,39 @@ package com.apm.utils
 	import com.apm.data.packages.PackageDefinitionFile;
 	import com.apm.data.packages.PackageDependency;
 	import com.apm.data.packages.PackageIdentifier;
-	import com.apm.data.packages.PackageIdentifier;
-	import com.apm.data.project.ProjectDefinition;
-	
+
 	import flash.filesystem.File;
-	
-	
+
 	/**
-	 * Utilities for checking packages available locally in the install cache
+	 * Utilities for checking package contents that have been
+	 * extracted for use in the project
 	 */
-	public class PackageCacheUtils
+	public class ProjectPackageCache
 	{
 		////////////////////////////////////////////////////////
 		//  CONSTANTS
 		//
-		
-		private static const TAG:String = "PackageCacheUtils";
-		
-		
+
+		private static const TAG:String = "ProjectPackageCache";
+
+
 		public static const PACKAGE_CACHE_DIR:String = "apm_packages";
-		
-		
+
+
 		////////////////////////////////////////////////////////
 		//  VARIABLES
 		//
-		
-		
+
+
 		////////////////////////////////////////////////////////
 		//  FUNCTIONALITY
 		//
-		
-		public function PackageCacheUtils()
+
+		public function ProjectPackageCache()
 		{
 		}
-		
-		
+
+
 		/**
 		 * Checks if the specified package is installed. Optionally specify the version if you need to
 		 * check for a specific version.
@@ -62,9 +60,9 @@ package com.apm.utils
 		 * @param version			Specific version to check. If <code>null</code> this will return true for any installed version of the package.
 		 * @return <code>true</code> if the package is installed and <code>false</code> if not.
 		 */
-		public static function isPackageInstalled( packageIdentifier:String, version:SemVer=null ):Boolean
+		public static function isPackageInstalled( packageIdentifier:String, version:SemVer = null ):Boolean
 		{
-			var uninstallingPackageDir:File = PackageFileUtils.cacheDirForPackage( APM.config.packagesDirectory, packageIdentifier );
+			var uninstallingPackageDir:File = PackageFileUtils.contentsDirForPackage( APM.config.packagesDirectory, packageIdentifier );
 			var f:File = uninstallingPackageDir.resolvePath( PackageDefinitionFile.DEFAULT_FILENAME );
 			if (!f.exists)
 			{
@@ -82,8 +80,8 @@ package com.apm.utils
 			}
 			return true;
 		}
-		
-		
+
+
 		/**
 		 * Iterates over the locally installed packages and checks the listed dependencies for the specified package identifier
 		 *
@@ -98,8 +96,8 @@ package com.apm.utils
 			{
 				return false;
 			}
-			
-			for each (var packageDefinition:PackageDefinitionFile in getCachedPackages())
+
+			for each (var packageDefinition:PackageDefinitionFile in getPackages())
 			{
 				Log.d( TAG, "isPackageRequiredDependency() : Checking : " + packageDefinition.packageDef.identifier );
 
@@ -107,7 +105,7 @@ package com.apm.utils
 				if (PackageIdentifier.isEquivalent( packageDefinition.packageDef.identifier, uninstallingPackageIdentifier )
 						|| PackageIdentifier.isEquivalent( packageDefinition.packageDef.identifier, packageIdentifier ))
 					continue;
-				
+
 				for each (var dep:PackageDependency in packageDefinition.dependencies)
 				{
 					Log.d( TAG, "isPackageRequiredDependency() : Checking dependency [" + packageDefinition.packageDef.identifier + "] : " + dep.identifier );
@@ -117,14 +115,14 @@ package com.apm.utils
 			}
 			return false;
 		}
-		
-		
+
+
 		/**
-		 * Returns an array of packages that are installed in the local cache.
+		 * Returns an array of packages that are extracted in the project.
 		 *
 		 * @return A <code>Vector</code> of <code>PackageDefinitionFile</code> references for each package installed
 		 */
-		public static function getCachedPackages():Vector.<PackageDefinitionFile>
+		public static function getPackages():Vector.<PackageDefinitionFile>
 		{
 			var cachedPackages:Vector.<PackageDefinitionFile> = new Vector.<PackageDefinitionFile>();
 			var packagesDir:File = new File( APM.config.packagesDirectory );
@@ -134,7 +132,7 @@ package com.apm.utils
 				{
 					if (packageDir.isDirectory)
 					{
-						var projectDefinitionFile:File = packageDir.resolvePath( PackageFileUtils.cacheDirName() + "/" + PackageDefinitionFile.DEFAULT_FILENAME );
+						var projectDefinitionFile:File = packageDir.resolvePath( PackageFileUtils.contentsDirName() + "/" + PackageDefinitionFile.DEFAULT_FILENAME );
 						if (projectDefinitionFile.exists)
 						{
 							var packageDefinition:PackageDefinitionFile = new PackageDefinitionFile().load( projectDefinitionFile );
@@ -145,19 +143,19 @@ package com.apm.utils
 			}
 			return cachedPackages;
 		}
-		
-		
+
+
 		/**
-		 * Find the cached PackageDefinitionFile for the specified identifier
+		 * Find the extracted <code>PackageDefinitionFile</code> for the specified identifier
 		 *
-		 * @param identifier The package identifier to search the cache for
+		 * @param identifier The package identifier to search the extracted contents for
 		 *
-		 * @return A PackageDefinitionFile representing the cached package or null if not found
+		 * @return A <code>PackageDefinitionFile</code> representing the extracted package or null if not found
 		 */
-		public static function getCachedPackage( identifier:String ):PackageDefinitionFile
+		public static function getPackage( identifier:String ):PackageDefinitionFile
 		{
-			var cachedPackages:Vector.<PackageDefinitionFile> = getCachedPackages();
-			for each (var cachedPackage:PackageDefinitionFile in cachedPackages)
+			var extractedPackages:Vector.<PackageDefinitionFile> = getPackages();
+			for each (var cachedPackage:PackageDefinitionFile in extractedPackages)
 			{
 				if (PackageIdentifier.isEquivalent( cachedPackage.packageDef.identifier, identifier ))
 				{
@@ -166,8 +164,8 @@ package com.apm.utils
 			}
 			return null;
 		}
-		
-		
+
+
 	}
-	
+
 }

--- a/client/src/com/apple/plist/PlistUtils.as
+++ b/client/src/com/apple/plist/PlistUtils.as
@@ -17,8 +17,8 @@ package com.apple.plist
 	import com.apple.plist.entries.PlistBooleanEntry;
 	import com.apple.plist.entries.PlistDictEntry;
 	import com.apple.plist.entries.PlistEntry;
-	
-	
+	import com.apple.plist.entries.PlistStringEntry;
+
 	/**
 	 *
 	 */
@@ -27,20 +27,20 @@ package com.apple.plist
 		////////////////////////////////////////////////////////
 		//  CONSTANTS
 		//
-		
+
 		private static const TAG:String = "Plist";
-		
-		
+
+
 		////////////////////////////////////////////////////////
 		//  VARIABLES
 		//
-		
-		
+
+
 		////////////////////////////////////////////////////////
 		//  FUNCTIONALITY
 		//
-		
-		
+
+
 		/**
 		 * Combines the values in the two plist files and produces a new merged.
 		 * <br/>
@@ -59,14 +59,14 @@ package com.apple.plist
 			{
 				var entryA:PlistEntry = plistA.getEntry( key );
 				var entryB:PlistEntry = plistB.getEntry( key );
-				
+
 				out.addEntry( mergeEntry( entryA, entryB ) );
 			}
-			
+
 			return out;
 		}
-		
-		
+
+
 		private static function uniqueJoin( a:Array, b:Array ):Array
 		{
 			var result:Array = a.concat();
@@ -84,50 +84,63 @@ package com.apple.plist
 			}
 			return result;
 		}
-		
-		
+
+
 		public static function mergeEntry( entryA:PlistEntry, entryB:PlistEntry ):PlistEntry
 		{
 			if (entryA == null) return entryB;
 			if (entryB == null) return entryA;
-			
+
 			if (entryA.type != entryB.type)
 				throw new Error( "cannot merge differing entry types for key: " + entryA.key );
-			
+
 			switch (entryA.type)
 			{
 				case "string":
 				{
+					var entryAString:PlistStringEntry = entryA as PlistStringEntry;
+					var entryBString:PlistStringEntry = entryB as PlistStringEntry;
+
+					// Custom handling of some fields
+					if (entryA.key == "MinimumOSVersion")
+					{
+						var numericA:Number = Number( entryAString.value );
+						var numericB:Number = Number( entryBString.value );
+
+						if (numericA > numericB) return entryA;
+						else return entryB;
+					}
+
 					// Return the first entry
 					return entryA;
 				}
-				
+
 				case "bool":
 				{
 					// Return the value that is "true" or return the first entry
 					var entryABool:PlistBooleanEntry = entryA as PlistBooleanEntry;
 					var entryBBool:PlistBooleanEntry = entryB as PlistBooleanEntry;
-					
+
 					if (entryABool.value) return entryABool;
 					if (entryBBool.value) return entryBBool;
 					return entryABool;
 				}
-				
+
 				case "dict":
 				{
 					// Iterate over each key and merge values
 					var entryADict:PlistDictEntry = entryA as PlistDictEntry;
 					var entryBDict:PlistDictEntry = entryB as PlistDictEntry;
-					
+
 					var mergedDictEntry:PlistDictEntry = new PlistDictEntry( entryADict.key );
-					
+
 					var keys:Array = uniqueJoin( entryADict.keys(), entryBDict.keys() );
-					
+
 					for each (var key:String in keys)
 					{
 						var entryFromEntryADict:PlistEntry = entryADict.getEntry( key );
 						var entryFromEntryBDict:PlistEntry = entryBDict.getEntry( key );
-						
+
 						mergedDictEntry.addEntry(
 								mergeEntry(
 										entryFromEntryADict,
@@ -135,36 +148,36 @@ package com.apple.plist
 								)
 						);
 					}
-					
+
 					return mergedDictEntry;
 				}
-				
+
 				case "array":
 				{
 					// Ensure each value is unique - can have multiple of the same type
 					var entryAArray:PlistArrayEntry = entryA as PlistArrayEntry;
 					var entryBArray:PlistArrayEntry = entryB as PlistArrayEntry;
-					
+
 					var mergedArrayEntry:PlistArrayEntry = new PlistArrayEntry( entryAArray.key );
-					
+
 					for each (var entryInA:PlistEntry in entryAArray.entries)
 					{
 						mergedArrayEntry.addEntry( entryInA );
 					}
-					
+
 					for each (var entryInB:PlistEntry in entryBArray.entries)
 					{
 						mergedArrayEntry.addEntry( entryInB );
 					}
-					
+
 					return mergedArrayEntry;
 				}
 			}
-			
+
 			return entryA;
 		}
-		
-		
+
+
 	}
-	
+
 }

--- a/client/src/com/apple/plist/PlistUtils.as
+++ b/client/src/com/apple/plist/PlistUtils.as
@@ -54,9 +54,7 @@ package com.apple.plist
 		public static function merge( plistA:Plist, plistB:Plist ):Plist
 		{
 			var out:Plist = new Plist();
-			
 			var keys:Array = uniqueJoin( plistA.keys(), plistB.keys() );
-			
 			for each (var key:String in keys)
 			{
 				var entryA:PlistEntry = plistA.getEntry( key );

--- a/client/src/com/apple/plist/entries/PlistCommentEntry.as
+++ b/client/src/com/apple/plist/entries/PlistCommentEntry.as
@@ -1,0 +1,89 @@
+/**
+ *        __       __               __
+ *   ____/ /_ ____/ /______ _ ___  / /_
+ *  / __  / / ___/ __/ ___/ / __ `/ __/
+ * / /_/ / (__  ) / / /  / / /_/ / /
+ * \__,_/_/____/_/ /_/  /_/\__, /_/
+ *                           / /
+ *                           \/
+ * http://distriqt.com
+ *
+ * @author 		Michael (https://github.com/marchbold)
+ * @created		10/9/21
+ */
+package com.apple.plist.entries
+{
+	import mx.utils.UIDUtil;
+
+	/**
+	 *
+	 */
+	public class PlistCommentEntry extends PlistEntry
+	{
+		////////////////////////////////////////////////////////
+		//  CONSTANTS
+		//
+
+		private static const TAG:String = "PlistDictEntry";
+
+
+		////////////////////////////////////////////////////////
+		//  VARIABLES
+		//
+
+		private var _value:String;
+
+		////////////////////////////////////////////////////////
+		//  FUNCTIONALITY
+		//
+
+		public function PlistCommentEntry()
+		{
+			super( generateUniqueIdentifier(), "comment" );
+		}
+
+
+		private function generateUniqueIdentifier():String
+		{
+			return "comment-" + UIDUtil.createUID();
+		}
+
+
+		public function get value():String
+		{
+			return _value;
+		}
+
+
+		public function set value( value:String ):void
+		{
+			_value = value;
+		}
+
+
+		override public function keyXML():XML
+		{
+			return new XML();
+		}
+
+
+		override public function valueXML():XML
+		{
+			return new XML( value );
+		}
+
+
+		override public function equals( entry:PlistEntry ):Boolean
+		{
+			if (super.equals( entry ))
+			{
+				return (value == (entry as PlistCommentEntry).value);
+			}
+			return false;
+		}
+
+
+	}
+
+
+}

--- a/client/src/com/apple/plist/entries/PlistEntry.as
+++ b/client/src/com/apple/plist/entries/PlistEntry.as
@@ -133,7 +133,15 @@ package com.apple.plist.entries
 						key = "";
 						break;
 					}
-					
+
+					case "null":
+					{
+						var commentEntry:PlistCommentEntry = new PlistCommentEntry();
+						commentEntry.value = node.toString();
+						entries.push( commentEntry );
+						key = "";
+						break;
+					}
 				}
 				
 			}

--- a/version.config
+++ b/version.config
@@ -1,6 +1,6 @@
 #Fri, 19 Aug 2022 12:30:31 +1000
 
 version_major=1
-version_minor=2
+version_minor=3
 version_build=0
 version_preview=

--- a/version.config
+++ b/version.config
@@ -1,6 +1,6 @@
-#Thu, 23 Jun 2022 16:44:14 +1000
+#Fri, 19 Aug 2022 12:30:31 +1000
 
 version_major=1
-version_minor=1
-version_build=7
+version_minor=2
+version_build=0
 version_preview=


### PR DESCRIPTION
feat(app-descriptor): ios plist merge takes highest minimum os version from packages and config
fix(install): correct install detection of local airpackage file
feat(cache): add local user cache for downloaded packages to avoid download for different projects
feat(generate): add handling of comments in plist merges for iOS info additions and entitlements
feat(templates): update android manifest and ios info addition config templates
feat(data): add ability to set different application identifiers for build types (resolves #157)
fix(windows): add overwrite flag for existing temp zip file (resolves #150)
feat(windows): improved hash code detection from certutil output on Windows server (#149)