### PR TITLE
Release v2.2.0

### DIFF
--- a/client/src/com/apm/client/commands/packages/InstallCommand.as
+++ b/client/src/com/apm/client/commands/packages/InstallCommand.as
@@ -19,6 +19,7 @@ package com.apm.client.commands.packages
 	import com.apm.data.packages.PackageDependency;
 	import com.apm.data.project.ProjectDefinition;
 	import com.apm.data.project.ProjectLock;
+	import com.apm.data.project.ProjectPackageDependency;
 	import com.apm.utils.FileUtils;
 	import com.apm.utils.PackageFileUtils;
 
@@ -46,7 +47,7 @@ package com.apm.client.commands.packages
 
 		private var _queue:ProcessQueue;
 		private var _installData:InstallData;
-
+		private var _options:Object = {};
 
 		////////////////////////////////////////////////////////
 		//  FUNCTIONALITY
@@ -104,8 +105,46 @@ package com.apm.client.commands.packages
 					"apm install <path/local.airpackage>  install a local airpackage at the specified path\n" +
 					"\n" +
 					"options: \n" +
-					"  --include-prerelease               includes pre-release package versions in the search"
+					"  --include-prerelease               includes pre-release package versions in the search\n"
+//					"  --delay-load                       marks the installed package as delay load in the project file"
 					;
+		}
+
+
+		private function processOption( optionLine:String, defaultValue:String = "" ):Object
+		{
+			var optionParts:Array = optionLine.substr( 2 ).split( "=" );
+			if (optionParts.length > 1)
+			{
+				return {
+					name : optionParts[0],
+					value: optionParts[1]
+				};
+			}
+			return {
+				name : optionLine.substr( 2 ),
+				value: defaultValue
+			};
+		}
+
+
+		private function processParametersForOptions( parameters:Array ):Object
+		{
+			var options:Object = {};
+			if (parameters != null)
+			{
+				for (var i:int = parameters.length - 1; i >= 0; --i)
+				{
+					var param:String = parameters[i];
+					if (param.indexOf( "--delay-load" ) == 0)
+					{
+						parameters.splice( i, 1 );
+						var option:Object = processOption( param, "true" );
+						options[option.name] = option.value;
+					}
+				}
+			}
+			return options;
 		}
 
 
@@ -121,6 +160,8 @@ package com.apm.client.commands.packages
 
 			_installData = new InstallData();
 			_queue = new ProcessQueue();
+
+			_installData.options = processParametersForOptions( _parameters );
 
 			var packageIdentifierOrPath:String = null;
 			if (_parameters != null && _parameters.length > 0)
@@ -195,6 +236,7 @@ package com.apm.client.commands.packages
 					}
 
 					// Install
+					_installData.request = request;
 					_queue.addProcess(
 							new InstallQueryPackageProcess(
 									_installData,
@@ -222,7 +264,7 @@ package com.apm.client.commands.packages
 			if (project.dependencies.length > 0)
 			{
 				// Install from list in project file
-				for each (var dep:PackageDependency in project.dependencies)
+				for each (var dep:ProjectPackageDependency in project.dependencies)
 				{
 					if (!_installData.containsPackage( dep.identifier ))
 					{

--- a/client/src/com/apm/client/commands/packages/ListCommand.as
+++ b/client/src/com/apm/client/commands/packages/ListCommand.as
@@ -6,7 +6,9 @@ package com.apm.client.commands.packages
 {
 	import com.apm.client.APM;
 	import com.apm.client.commands.Command;
+	import com.apm.client.io.utils.ListOutput;
 	import com.apm.client.events.CommandEvent;
+	import com.apm.data.install.InstallPackageData;
 	import com.apm.data.project.ProjectDefinition;
 
 	import flash.events.EventDispatcher;
@@ -72,7 +74,7 @@ package com.apm.client.commands.packages
 
 		public function get description():String
 		{
-			return "lists dependencies currently added to your project";
+			return "lists packages currently added to your project";
 		}
 
 
@@ -80,7 +82,11 @@ package com.apm.client.commands.packages
 		{
 			return description + "\n" +
 					"\n" +
-					"apm list          list all the dependencies in your project\n"
+					"apm list          list all the packages in your project\n" +
+					"\n" +
+					"options: \n" +
+					"  --dependencies(--deps)  include package dependencies in the list\n" +
+					"                          (default will only list the project installed packages)\n"
 		}
 
 
@@ -94,20 +100,55 @@ package com.apm.client.commands.packages
 				return;
 			}
 
+			var includeDependencies:Boolean = false;
+			if (_parameters != null)
+			{
+				for each (var param:String in _parameters)
+				{
+					if (param == "--dependencies" || param == "--deps" || param == "--all")
+					{
+						includeDependencies = true;
+					}
+				}
+			}
+
 			APM.io.writeLine( project.getApplicationId( APM.config.buildType ) + "@" + project.getVersion( APM.config.buildType ) + " " + APM.config.workingDirectory + "" );
 			if (project.dependencies.length == 0)
 			{
-				APM.io.writeLine( "└── (empty)" );
+				APM.io.writeLine( ListOutput.marker() + "(empty)" );
 			}
 			else
 			{
-				for (var i:int = 0; i < project.dependencies.length; i++)
+				if (includeDependencies)
 				{
-					APM.io.writeLine(
-							(i == project.dependencies.length - 1 ? "└──" : "├──") +
-							project.dependencies[i].toString() );
+					if (APM.config.projectLock == null)
+					{
+						APM.io.writeLine( "ERROR: project lock not found, run 'apm install' first" );
+						dispatchEvent( new CommandEvent( CommandEvent.COMPLETE, APM.CODE_ERROR ) );
+						return;
+					}
+
+					var allDependencies:Vector.<InstallPackageData> = APM.config.projectLock.dependencies;
+					for (var j:int = 0; j < allDependencies.length; j++)
+					{
+						var installData:InstallPackageData = allDependencies[j];
+						APM.io.writeLine(
+								ListOutput.marker(j == allDependencies.length - 1 ) +
+								installData.packageVersion.toStringWithIdentifier()
+						);
+					}
+				}
+				else
+				{
+					for (var i:int = 0; i < project.dependencies.length; i++)
+					{
+						APM.io.writeLine(
+								ListOutput.marker(i == project.dependencies.length - 1 ) +
+								project.dependencies[i].toString() );
+					}
 				}
 			}
+
 			dispatchEvent( new CommandEvent( CommandEvent.COMPLETE, APM.CODE_OK ) );
 
 		}

--- a/client/src/com/apm/client/commands/packages/SearchCommand.as
+++ b/client/src/com/apm/client/commands/packages/SearchCommand.as
@@ -6,6 +6,7 @@ package com.apm.client.commands.packages
 {
 	import com.apm.client.APM;
 	import com.apm.client.commands.Command;
+	import com.apm.client.io.utils.ListOutput;
 	import com.apm.client.events.CommandEvent;
 	import com.apm.client.repositories.PackageResolver;
 	import com.apm.data.packages.PackageDefinition;
@@ -120,14 +121,14 @@ package com.apm.client.commands.packages
 								for (var i:int = 0; i < packages.length; i++)
 								{
 									APM.io.writeLine(
-											(i == packages.length - 1 ? "└──" : "├──") +
+											ListOutput.marker(i == packages.length - 1) +
 											packages[ i ].toDescriptiveString()
 									);
 								}
 							}
 							else
 							{
-								APM.io.writeLine( "└── no matching packages found" );
+								APM.io.writeLine( ListOutput.marker() + "no matching packages found" );
 							}
 							dispatchEvent( new CommandEvent( CommandEvent.COMPLETE, APM.CODE_OK ) );
 						}

--- a/client/src/com/apm/client/commands/packages/ViewCommand.as
+++ b/client/src/com/apm/client/commands/packages/ViewCommand.as
@@ -9,89 +9,89 @@ package com.apm.client.commands.packages
 	import com.apm.client.commands.packages.processes.ViewPackageProcess;
 	import com.apm.client.events.CommandEvent;
 	import com.apm.client.processes.ProcessQueue;
-	
+
 	import flash.events.EventDispatcher;
-	
-	
+
 	public class ViewCommand extends EventDispatcher implements Command
 	{
-		
+
 		////////////////////////////////////////////////////////
 		//  CONSTANTS
 		//
-		
+
 		private static const TAG:String = "ViewCommand";
-		
-		
+
+
 		public static const NAME:String = "view";
-		
-		
+
+
 		////////////////////////////////////////////////////////
 		//  VARIABLES
 		//
-		
+
 		private var _parameters:Array;
 		private var _queue:ProcessQueue;
-		
+
 		////////////////////////////////////////////////////////
 		//  FUNCTIONALITY
 		//
-		
+
 		public function ViewCommand()
 		{
 			super();
 			_queue = new ProcessQueue();
 		}
-		
-		
+
+
 		public function setParameters( parameters:Array ):void
 		{
 			_parameters = parameters;
 		}
-		
-		
+
+
 		public function get name():String
 		{
 			return NAME;
 		}
-		
-		
+
+
 		public function get category():String
 		{
 			return "";
 		}
-		
-		
+
+
 		public function get requiresNetwork():Boolean
 		{
 			return true;
 		}
-		
-		
+
+
 		public function get requiresProject():Boolean
 		{
 			return false;
 		}
-		
-		
+
+
 		public function get description():String
 		{
 			return "search for a dependency in the repository";
 		}
-		
-		
+
+
 		public function get usage():String
 		{
 			return description + "\n" +
-				   "\n" +
-				   "apm view <foo>           view information of a package called <foo> in the repository\n" +
-				   "\n" +
-				   "options: \n" +
-				   "  --include-prerelease   includes pre-release package versions in the search"
+					"\n" +
+					"apm view <foo>           view information of a package called <foo> in the repository\n" +
+					"apm view <foo> <version> view information of a package called <foo> with version <version> in the repository\n" +
+					"\n" +
+					"options: \n" +
+					"  --include-prerelease   includes pre-release package versions in the search"
 					;
 		}
-		
-		
+
+
 		public function execute():void
 		{
 			if (_parameters == null || _parameters.length == 0)
@@ -100,10 +100,21 @@ package com.apm.client.commands.packages
 				dispatchEvent( new CommandEvent( CommandEvent.COMPLETE, APM.CODE_ERROR ) );
 				return;
 			}
-			
-			var identifier:String = _parameters[ 0 ];
-			
-			_queue.addProcess( new ViewPackageProcess( identifier ) );
+
+			var identifier:String = _parameters[0];
+			var version:String = null;
+			if (identifier.indexOf( "@" ) >= 0)
+			{
+				var valueParts:Array = identifier.split( "@" );
+				identifier = valueParts[0];
+				version = valueParts[1];
+			}
+			if (_parameters.length > 1)
+			{
+				version = _parameters[1];
+			}
+
+			_queue.addProcess( new ViewPackageProcess( identifier, version ) );
 			_queue.start( function ():void
 						  {
 							  dispatchEvent( new CommandEvent( CommandEvent.COMPLETE, APM.CODE_OK ) );
@@ -114,7 +125,7 @@ package com.apm.client.commands.packages
 						  }
 			);
 		}
-		
+
 	}
-	
+
 }

--- a/client/src/com/apm/client/commands/packages/processes/InstallDataValidationProcess.as
+++ b/client/src/com/apm/client/commands/packages/processes/InstallDataValidationProcess.as
@@ -6,6 +6,7 @@ package com.apm.client.commands.packages.processes
 {
 	import com.apm.client.APM;
 	import com.apm.client.commands.packages.utils.InstallDataValidator;
+	import com.apm.client.io.utils.ListOutput;
 	import com.apm.client.processes.ProcessBase;
 	import com.apm.data.install.InstallData;
 	import com.apm.data.install.InstallPackageData;
@@ -84,7 +85,7 @@ package com.apm.client.commands.packages.processes
 					APM.io.writeError( "CONFLICT", confictGroup.packageIdentifier );
 					for (var i:int = 0; i < confictGroup.versions.length; i++)
 					{
-						var prefix:String = (i == confictGroup.versions.length - 1 ? "└── " : "├── ");
+						var prefix:String = ListOutput.marker(i == confictGroup.versions.length - 1);
 
 						var version:String = confictGroup.versions[i].packageVersion.toString();
 

--- a/client/src/com/apm/client/commands/packages/processes/InstallFinaliseProcess.as
+++ b/client/src/com/apm/client/commands/packages/processes/InstallFinaliseProcess.as
@@ -12,10 +12,10 @@ package com.apm.client.commands.packages.processes
 	import com.apm.data.common.PlatformParameter;
 	import com.apm.data.install.InstallData;
 	import com.apm.data.install.InstallPackageData;
-	import com.apm.data.packages.PackageDependency;
 	import com.apm.data.packages.PackageParameter;
 	import com.apm.data.packages.PackageVersion;
 	import com.apm.data.project.ProjectLock;
+	import com.apm.data.project.ProjectPackageDependency;
 
 	import flash.filesystem.File;
 
@@ -65,7 +65,7 @@ package com.apm.client.commands.packages.processes
 
 				if (p.request.requiringPackage == null)
 				{
-					var dependency:PackageDependency = new PackageDependency();
+					var dependency:ProjectPackageDependency = new ProjectPackageDependency();
 					dependency.identifier            = packageVersion.packageDef.identifier;
 					dependency.version               = SemVerRange.fromString( p.request.version );
 					dependency.source                = p.request.source;

--- a/client/src/com/apm/client/commands/packages/processes/InstallLocalPackageProcess.as
+++ b/client/src/com/apm/client/commands/packages/processes/InstallLocalPackageProcess.as
@@ -62,16 +62,17 @@ package com.apm.client.commands.packages.processes
 			subqueue.start(
 					function ():void
 					{
-						_installData.addPackage( packageDefinitionFile.version,
-												 new InstallRequest(
-														 packageDefinitionFile.packageDef.identifier,
-														 packageDefinitionFile.version.version.toString(),
-														 "file",
-														 null,
-														 true,
-														 _packageFile
-												 )
+						var request:InstallRequest = new InstallRequest(
+								packageDefinitionFile.packageDef.identifier,
+								packageDefinitionFile.version.version.toString(),
+								"file",
+								null,
+								true,
+								_packageFile
 						);
+
+						_installData.request = request;
+						_installData.addPackage( packageDefinitionFile.version, request );
 
 						// Queue dependencies for install
 						for each (var dep:PackageDependency in packageDefinitionFile.dependencies)

--- a/client/src/com/apm/client/commands/packages/processes/PackageGetProcess.as
+++ b/client/src/com/apm/client/commands/packages/processes/PackageGetProcess.as
@@ -5,6 +5,7 @@
 package com.apm.client.commands.packages.processes
 {
 	import com.apm.client.APM;
+	import com.apm.client.io.utils.ListOutput;
 	import com.apm.client.processes.ProcessBase;
 	import com.apm.data.packages.PackageDefinitionFile;
 
@@ -125,14 +126,14 @@ package com.apm.client.commands.packages.processes
 					APM.io.writeLine( "platforms" );
 					if (packageDefinitionFile.version.platforms.length == 0)
 					{
-						APM.io.writeLine( "└── (all)" );
+						APM.io.writeLine( ListOutput.marker() + "(all)" );
 					}
 					else
 					{
 						for (var p:int = 0; p < packageDefinitionFile.version.platforms.length; p++)
 						{
 							APM.io.writeLine(
-									(p == packageDefinitionFile.version.platforms.length - 1 ? "└──" : "├──") +
+									ListOutput.marker(p == packageDefinitionFile.version.platforms.length - 1) +
 									packageDefinitionFile.version.platforms[p].toString() );
 						}
 					}
@@ -145,14 +146,14 @@ package com.apm.client.commands.packages.processes
 					APM.io.writeLine( "dependencies" );
 					if (packageDefinitionFile.dependencies.length == 0)
 					{
-						APM.io.writeLine( "└── (none)" );
+						APM.io.writeLine( ListOutput.marker() + "(none)" );
 					}
 					else
 					{
 						for (var d:int = 0; d < packageDefinitionFile.dependencies.length; d++)
 						{
 							APM.io.writeLine(
-									(d == packageDefinitionFile.dependencies.length - 1 ? "└──" : "├──") +
+									ListOutput.marker(d == packageDefinitionFile.dependencies.length - 1) +
 									packageDefinitionFile.dependencies[d].toString() );
 						}
 					}
@@ -164,14 +165,14 @@ package com.apm.client.commands.packages.processes
 					APM.io.writeLine( "tags" );
 					if (packageDefinitionFile.packageDef.tags.length == 0)
 					{
-						APM.io.writeLine( "└── (none)" );
+						APM.io.writeLine( ListOutput.marker() + "(none)" );
 					}
 					else
 					{
 						for (var t:int = 0; t < packageDefinitionFile.packageDef.tags.length; t++)
 						{
 							APM.io.writeLine(
-									(t == packageDefinitionFile.packageDef.tags.length - 1 ? "└──" : "├──") +
+									ListOutput.marker(t == packageDefinitionFile.packageDef.tags.length - 1) +
 									packageDefinitionFile.packageDef.tags[t].toString() );
 						}
 					}

--- a/client/src/com/apm/client/commands/packages/processes/ViewPackageProcess.as
+++ b/client/src/com/apm/client/commands/packages/processes/ViewPackageProcess.as
@@ -4,96 +4,151 @@
  */
 package com.apm.client.commands.packages.processes
 {
+	import com.apm.SemVerRange;
 	import com.apm.client.APM;
 	import com.apm.client.processes.ProcessBase;
 	import com.apm.client.repositories.PackageResolver;
 	import com.apm.data.packages.PackageDefinition;
+	import com.apm.data.packages.PackageDependency;
 	import com.apm.data.packages.PackageVersion;
-	
-	
+
 	public class ViewPackageProcess extends ProcessBase
 	{
 		////////////////////////////////////////////////////////
 		//  CONSTANTS
 		//
-		
+
 		private static const TAG:String = "ViewPackageProcess";
-		
-		
+
+
 		////////////////////////////////////////////////////////
 		//  VARIABLES
 		//
-		
+
 		private var _packageIdentifier:String;
-		
-		
+		private var _packageVersion:SemVerRange;
+
+
 		////////////////////////////////////////////////////////
 		//  FUNCTIONALITY
 		//
-		
-		public function ViewPackageProcess( packageIdentifier:String )
+
+		public function ViewPackageProcess( packageIdentifier:String, packageVersion:String = null )
 		{
 			super();
 			_packageIdentifier = packageIdentifier;
+			_packageVersion = SemVerRange.fromString( packageVersion );
 		}
-		
-		
+
+
 		override public function start( completeCallback:Function = null, failureCallback:Function = null ):void
 		{
 			super.start( completeCallback, failureCallback );
-			APM.io.showSpinner( "Finding package : " + _packageIdentifier );
-			PackageResolver.instance.getPackage(
-					_packageIdentifier,
-					null,
-					function ( success:Boolean, packageDefinition:PackageDefinition ):void
-					{
-						APM.io.stopSpinner( success, "No package found matching : " + _packageIdentifier, success );
-						if (success)
-						{
-							APM.io.writeLine( packageDefinition.toDescriptiveString() );
-							
-							if (packageDefinition.license != null && packageDefinition.license.type != "none")
-							{
-								APM.io.writeLine( "license" );
-								APM.io.writeLine( "└── " + packageDefinition.license.toDescriptiveString() );
-								if (!packageDefinition.license.isPublic)
-								{
-									APM.io.writeLine( "└── more info: " + packageDefinition.purchaseUrl );
-								}
-							}
-							
-							var tagsLine:String = "";
-							for each (var tag:String in packageDefinition.tags)
-							{
-								tagsLine += tag + " ";
-							}
-							APM.io.writeLine( "tags" );
-							APM.io.writeLine( "└── [ " + tagsLine + " ]" );
-							
-							if (packageDefinition.versions.length == 0)
-							{
-								APM.io.writeLine( "└── (empty)" );
-							}
-							else
-							{
-								APM.io.writeLine( "versions" );
-								for (var i:int = 0; i < packageDefinition.versions.length; i++)
-								{
-									var v:PackageVersion = packageDefinition.versions[ i ];
-									APM.io.writeLine(
-											(i == packageDefinition.versions.length - 1 ? "└──" : "├──") +
-											v.toDescriptiveString() );
-								}
-							}
-							
-						}
-						complete();
-					}
-			);
-			
+			if (_packageVersion != null)
+			{
+				APM.io.showSpinner( "Finding package : " + _packageIdentifier + "@" + _packageVersion.toString() );
+				PackageResolver.instance.getPackageVersion(
+						_packageIdentifier,
+						_packageVersion,
+						null,
+						null,
+						packageResultHandler );
+			}
+			else
+			{
+				APM.io.showSpinner( "Finding package : " + _packageIdentifier );
+				PackageResolver.instance.getPackage(
+						_packageIdentifier,
+						null,
+						packageResultHandler
+				);
+			}
 		}
-		
-		
+
+
+		private function packageResultHandler( success:Boolean, packageDefinition:PackageDefinition ):void
+		{
+			APM.io.stopSpinner( success, "No package found matching : " + _packageIdentifier, success );
+			if (success)
+			{
+				APM.io.writeLine( packageDefinition.toDescriptiveString() );
+
+				if (packageDefinition.license != null && packageDefinition.license.type != "none")
+				{
+					APM.io.writeLine( "license" );
+					APM.io.writeLine(
+							listMarker( packageDefinition.license.isPublic ) +
+							packageDefinition.license.toDescriptiveString() );
+					if (!packageDefinition.license.isPublic)
+					{
+						APM.io.writeLine( listMarker() + "more info: " + packageDefinition.purchaseUrl );
+					}
+				}
+
+				var tagsLine:String = "";
+				for each (var tag:String in packageDefinition.tags)
+				{
+					tagsLine += tag + " ";
+				}
+				APM.io.writeLine( "tags" );
+				APM.io.writeLine( listMarker() + "[ " + tagsLine + " ]" );
+
+				printVersions( packageDefinition.versions );
+			}
+			complete();
+		}
+
+
+		private function printVersions( versions:Vector.<PackageVersion> ):void
+		{
+			APM.io.writeLine( "versions" );
+			var shouldPrintDependencies:Boolean = (versions.length == 1);
+			if (versions.length == 0)
+			{
+				APM.io.writeLine( listMarker() + "(empty)" );
+			}
+			else
+			{
+				for (var i:int = 0; i < versions.length; i++)
+				{
+					var v:PackageVersion = versions[i];
+					APM.io.writeLine(
+							listMarker( i == versions.length - 1 ) +
+							v.toDescriptiveString() );
+					if (shouldPrintDependencies)
+					{
+						printDependencies( v.dependencies, "    " );
+					}
+				}
+			}
+		}
+
+
+		private function printDependencies( dependencies:Vector.<PackageDependency>, prefix:String = "" ):void
+		{
+			APM.io.writeLine( prefix + "dependencies" );
+			if (dependencies.length == 0)
+			{
+				APM.io.writeLine( prefix + listMarker() + "(none)" );
+			}
+			else
+			{
+				for (var i:int = 0; i < dependencies.length; i++)
+				{
+					APM.io.writeLine(
+							prefix +
+							listMarker( i == dependencies.length - 1 ) +
+							dependencies[i].toString() );
+				}
+			}
+		}
+
+
+		private function listMarker( isLast:Boolean = true ):String
+		{
+			return (isLast ? "└── " : "├── ");
+		}
+
 	}
-	
+
 }

--- a/client/src/com/apm/client/commands/packages/processes/ViewPackageProcess.as
+++ b/client/src/com/apm/client/commands/packages/processes/ViewPackageProcess.as
@@ -6,6 +6,7 @@ package com.apm.client.commands.packages.processes
 {
 	import com.apm.SemVerRange;
 	import com.apm.client.APM;
+	import com.apm.client.io.utils.ListOutput;
 	import com.apm.client.processes.ProcessBase;
 	import com.apm.client.repositories.PackageResolver;
 	import com.apm.data.packages.PackageDefinition;
@@ -77,11 +78,11 @@ package com.apm.client.commands.packages.processes
 				{
 					APM.io.writeLine( "license" );
 					APM.io.writeLine(
-							listMarker( packageDefinition.license.isPublic ) +
+							ListOutput.marker( packageDefinition.license.isPublic ) +
 							packageDefinition.license.toDescriptiveString() );
 					if (!packageDefinition.license.isPublic)
 					{
-						APM.io.writeLine( listMarker() + "more info: " + packageDefinition.purchaseUrl );
+						APM.io.writeLine( ListOutput.marker() + "more info: " + packageDefinition.purchaseUrl );
 					}
 				}
 
@@ -91,7 +92,7 @@ package com.apm.client.commands.packages.processes
 					tagsLine += tag + " ";
 				}
 				APM.io.writeLine( "tags" );
-				APM.io.writeLine( listMarker() + "[ " + tagsLine + " ]" );
+				APM.io.writeLine( ListOutput.marker() + "[ " + tagsLine + " ]" );
 
 				printVersions( packageDefinition.versions );
 			}
@@ -105,7 +106,7 @@ package com.apm.client.commands.packages.processes
 			var shouldPrintDependencies:Boolean = (versions.length == 1);
 			if (versions.length == 0)
 			{
-				APM.io.writeLine( listMarker() + "(empty)" );
+				APM.io.writeLine( ListOutput.marker() + "(empty)" );
 			}
 			else
 			{
@@ -113,7 +114,7 @@ package com.apm.client.commands.packages.processes
 				{
 					var v:PackageVersion = versions[i];
 					APM.io.writeLine(
-							listMarker( i == versions.length - 1 ) +
+							ListOutput.marker( i == versions.length - 1 ) +
 							v.toDescriptiveString() );
 					if (shouldPrintDependencies)
 					{
@@ -129,7 +130,7 @@ package com.apm.client.commands.packages.processes
 			APM.io.writeLine( prefix + "dependencies" );
 			if (dependencies.length == 0)
 			{
-				APM.io.writeLine( prefix + listMarker() + "(none)" );
+				APM.io.writeLine( prefix + ListOutput.marker() + "(none)" );
 			}
 			else
 			{
@@ -137,17 +138,14 @@ package com.apm.client.commands.packages.processes
 				{
 					APM.io.writeLine(
 							prefix +
-							listMarker( i == dependencies.length - 1 ) +
+							ListOutput.marker( i == dependencies.length - 1 ) +
 							dependencies[i].toString() );
 				}
 			}
 		}
 
 
-		private function listMarker( isLast:Boolean = true ):String
-		{
-			return (isLast ? "└── " : "├── ");
-		}
+
 
 	}
 

--- a/client/src/com/apm/client/commands/project/processes/ApplicationDescriptorGenerationProcess.as
+++ b/client/src/com/apm/client/commands/project/processes/ApplicationDescriptorGenerationProcess.as
@@ -105,7 +105,8 @@ package com.apm.client.commands.project.processes
 						if (APM.config.projectDefinition.shouldIncludePackage( packageDefinition.version ))
 						{
 							_appDescriptor.addExtension(
-									PackageIdentifier.identifierWithoutVariant( packageDefinition.packageDef.identifier )
+									PackageIdentifier.identifierWithoutVariant( packageDefinition.packageDef.identifier ),
+									APM.config.projectDefinition.shouldDelayLoadPackage( packageDefinition.packageDef.identifier, APM.config.buildType )
 							);
 						}
 					}

--- a/client/src/com/apm/client/commands/project/processes/ProjectDefinitionImportProcess.as
+++ b/client/src/com/apm/client/commands/project/processes/ProjectDefinitionImportProcess.as
@@ -15,6 +15,7 @@ package com.apm.client.commands.project.processes
 	import com.apm.data.packages.PackageVersion;
 	import com.apm.data.project.ApplicationDescriptor;
 	import com.apm.data.project.ProjectDefinition;
+	import com.apm.data.project.ProjectPackageDependency;
 
 	import flash.filesystem.File;
 
@@ -157,7 +158,7 @@ package com.apm.client.commands.project.processes
 								{
 									APM.io.writeResult( true, "ADDING   : Package: " + packageVersion.toStringWithIdentifier() );
 
-									var dependency:PackageDependency = new PackageDependency();
+									var dependency:ProjectPackageDependency = new ProjectPackageDependency();
 									dependency.identifier = packageVersion.packageDef.identifier;
 									dependency.version = SemVerRange.fromString( packageVersion.version.toString() );
 									dependency.source = packageVersion.source;

--- a/client/src/com/apm/client/commands/project/processes/ProjectGetProcess.as
+++ b/client/src/com/apm/client/commands/project/processes/ProjectGetProcess.as
@@ -5,6 +5,7 @@
 package com.apm.client.commands.project.processes
 {
 	import com.apm.client.APM;
+	import com.apm.client.io.utils.ListOutput;
 	import com.apm.client.processes.ProcessBase;
 	import com.apm.data.common.Platform;
 	import com.apm.data.common.PlatformConfiguration;
@@ -67,14 +68,14 @@ package com.apm.client.commands.project.processes
 				APM.io.writeLine( "platforms" );
 				if (project.platforms.length == 0)
 				{
-					APM.io.writeLine( "└── (all)" );
+					APM.io.writeLine( ListOutput.marker() + "(all)" );
 				}
 				else
 				{
 					for (var p:int = 0; p < project.platforms.length; p++)
 					{
 						APM.io.writeLine(
-								(p == project.platforms.length - 1 ? "└──" : "├──") +
+								ListOutput.marker(p == project.platforms.length - 1) +
 								project.platforms[p].toString() );
 					}
 				}
@@ -85,11 +86,11 @@ package com.apm.client.commands.project.processes
 					platformConfig = project.getPlatformConfiguration( platform );
 					if (platformConfig == null) continue;
 
-					APM.io.writeLine( "└──" + platform );
+					APM.io.writeLine( ListOutput.marker() + platform );
 					for (var pp:int = 0; pp < platformConfig.parameters.length; pp++)
 					{
 						platformParam = platformConfig.parameters[pp];
-						APM.io.writeValue( "  " + (pp == platformConfig.parameters.length - 1 ? "└──" : "├──") + platformParam.name, platformParam.value );
+						APM.io.writeValue( "  " + ListOutput.marker(pp == platformConfig.parameters.length - 1) + platformParam.name, platformParam.value );
 					}
 				}
 
@@ -104,14 +105,14 @@ package com.apm.client.commands.project.processes
 				APM.io.writeLine( "dependencies" );
 				if (project.dependencies.length == 0)
 				{
-					APM.io.writeLine( "└── (empty)" );
+					APM.io.writeLine( ListOutput.marker() + "(empty)" );
 				}
 				else
 				{
 					for (var d:int = 0; d < project.dependencies.length; d++)
 					{
 						APM.io.writeLine(
-								(d == project.dependencies.length - 1 ? "└──" : "├──") +
+								ListOutput.marker(d == project.dependencies.length - 1) +
 								project.dependencies[d].toString() );
 					}
 				}

--- a/client/src/com/apm/client/io/utils/ListOutput.as
+++ b/client/src/com/apm/client/io/utils/ListOutput.as
@@ -1,0 +1,19 @@
+/**
+ * @author Michael Archbold (https://michaelarchbold.com)
+ * @created 3/11/2025
+ */
+package com.apm.client.io.utils
+{
+	public class ListOutput
+	{
+
+
+		public static function marker( isLast:Boolean = true ):String
+		{
+			return (isLast ? "└── " : "├── ");
+		}
+
+
+
+	}
+}

--- a/client/src/com/apm/data/install/InstallData.as
+++ b/client/src/com/apm/data/install/InstallData.as
@@ -65,16 +65,28 @@ package com.apm.data.install
 		public function get packagesConflicting():Vector.<InstallPackageDataGroup> { return _packagesConflicting; }
 
 
+		/**
+		 * The original install request that initiated this install data
+		 */
+		public var request:InstallRequest;
+
+
+		/**
+		 * Additional options for install process, eg delay load flag
+ 		 */
+		public var options:Object = {};
+
+
 		////////////////////////////////////////////////////////
 		//  FUNCTIONALITY
 		//
 
 		public function InstallData()
 		{
-			_packagesAll         = new Vector.<InstallPackageData>();
+			_packagesAll = new Vector.<InstallPackageData>();
 //			_packagesInstalled = new Vector.<InstallPackageData>();
-			_packagesToInstall   = new Vector.<InstallPackageData>();
-			_packagesToRemove    = new Vector.<InstallPackageData>();
+			_packagesToInstall = new Vector.<InstallPackageData>();
+			_packagesToRemove = new Vector.<InstallPackageData>();
 			_packagesConflicting = new Vector.<InstallPackageDataGroup>();
 		}
 
@@ -159,12 +171,18 @@ package com.apm.data.install
 
 		public function removePackageByIdentifier( identifier:String ):void
 		{
-			var packageDef:PackageDefinition  = new PackageDefinition();
-			packageDef.identifier             = identifier;
+			var packageDef:PackageDefinition = new PackageDefinition();
+			packageDef.identifier = identifier;
 			var packageVersion:PackageVersion = new PackageVersion();
-			packageVersion.packageDef         = packageDef;
+			packageVersion.packageDef = packageDef;
 
 			removePackage( packageVersion );
+		}
+
+
+		public function isSourceRequest( request:InstallRequest ):Boolean
+		{
+			return this.request.packageIdentifier == request.packageIdentifier;
 		}
 
 	}

--- a/client/src/com/apm/data/install/InstallData.as
+++ b/client/src/com/apm/data/install/InstallData.as
@@ -73,7 +73,7 @@ package com.apm.data.install
 
 		/**
 		 * Additional options for install process, eg delay load flag
- 		 */
+	 	 */
 		public var options:Object = {};
 
 
@@ -182,7 +182,7 @@ package com.apm.data.install
 
 		public function isSourceRequest( request:InstallRequest ):Boolean
 		{
-			return this.request.packageIdentifier == request.packageIdentifier;
+			return this.request != null && this.request.packageIdentifier == request.packageIdentifier;
 		}
 
 	}

--- a/client/src/com/apm/data/project/ApplicationDescriptor.as
+++ b/client/src/com/apm/data/project/ApplicationDescriptor.as
@@ -357,7 +357,7 @@ package com.apm.data.project
 			}
 
 			// Add new extension
-			var extensionNode:XML = <extensionID>{extensionID}</extensionID>
+			var extensionNode:XML = <extensionID>{extensionID}</extensionID>;
 			if (delayLoad) extensionNode.@delayLoad = true;
 			extensionList += extensionNode;
 

--- a/client/src/com/apm/data/project/ApplicationDescriptor.as
+++ b/client/src/com/apm/data/project/ApplicationDescriptor.as
@@ -6,8 +6,6 @@ package com.apm.data.project
 {
 	import airsdk.AIRSDKVersion;
 
-	import com.apm.SemVer;
-
 	import com.apm.client.logging.Log;
 	import com.apm.data.common.Platform;
 	import com.apm.data.common.PlatformConfiguration;
@@ -147,7 +145,7 @@ package com.apm.data.project
 
 				for each (var platform:String in Platform.ALL_PLATFORMS)
 				{
-					if (!project.shouldIncludePlatform(platform)) continue;
+					if (!project.shouldIncludePlatform( platform )) continue;
 					var platformConfig:PlatformConfiguration = project.getPlatformConfiguration( platform );
 					if (platformConfig == null) continue;
 					var platformNode:String = getNodeForPlatform( platform );
@@ -330,7 +328,7 @@ package com.apm.data.project
 		//	EXTENSIONS
 		//
 
-		public function addExtension( extensionID:String ):void
+		public function addExtension( extensionID:String, delayLoad:Boolean = false ):void
 		{
 			default xml namespace = _airNS;
 
@@ -339,43 +337,70 @@ package com.apm.data.project
 				_xml.extensions = <extensions/>;
 			}
 
-			var extensionIDs:Array = [];
-			for each (var extensionIDNode:XML in _xml.extensions..extensionID)
+			var existingDelayLoad:Boolean = false;
+			var extensionList:XMLList = new XMLList();
+			for each (var existingNode:XML in _xml.extensions..extensionID)
 			{
 				// Filter duplicates
-				if (existsInArray( extensionIDs, extensionIDNode.toString() ))
+				if (xmlListContains( extensionList, existingNode.toString() ))
 					continue;
-				extensionIDs.push( extensionIDNode.toString() );
+				// Filter new extension
+				if (existingNode.toString() == extensionID)
+				{
+					if (existingNode.@delayLoad != undefined)
+					{
+						existingDelayLoad = (existingNode.@delayLoad.toString() == "true");
+					}
+					continue;
+				}
+				extensionList += existingNode;
 			}
-			if (!existsInArray( extensionIDs, extensionID ))
-			{
-				extensionIDs.push( extensionID );
-			}
-			extensionIDs.sort();
 
-			_xml.extensions = <extensions/>;
-			for each (var extID:String in extensionIDs)
-			{
-				_xml.extensions.appendChild( <extensionID>{extID}</extensionID> );
-			}
+			// Add new extension
+			var extensionNode:XML = <extensionID>{extensionID}</extensionID>
+			if (delayLoad) extensionNode.@delayLoad = true;
+			extensionList += extensionNode;
+
+			_xml.extensions = <extensions>{sortXMLListByString( extensionList )}</extensions>;
 		}
 
-		private function existsInArray( arr:Array, value:* ):Boolean
+
+		private function xmlListContains( xmlList:XMLList, value:String ):Boolean
 		{
-			if (arr == null) return false;
-			for each (var item:* in arr)
+			for each (var item:XML in xmlList)
 			{
-				if (value == item)
+				if (item.toString() == value)
 					return true;
 			}
 			return false;
 		}
 
 
+		private function sortXMLListByString( xmlList:XMLList ):XMLList
+		{
+			var arr:Array = [];
+			for each (var item:XML in xmlList)
+			{
+				arr.push( item );
+			}
+			arr.sort( function ( a:XML, b:XML ):int
+					  {
+						  var aStr:String = a.toString();
+						  var bStr:String = b.toString();
+						  return aStr.localeCompare( bStr );
+					  } );
+			var sortedXMLList:XMLList = new XMLList();
+			for each (var sortedItem:XML in arr)
+			{
+				sortedXMLList += sortedItem;
+			}
+			return sortedXMLList;
+		}
+
+
 		public function removeAllExtensions():void
 		{
 			default xml namespace = _airNS;
-
 			_xml.extensions = <extensions/>;
 		}
 

--- a/client/src/com/apm/data/project/ProjectDefinition.as
+++ b/client/src/com/apm/data/project/ProjectDefinition.as
@@ -13,6 +13,7 @@ package com.apm.data.project
 	import com.apm.data.packages.PackageParameter;
 	import com.apm.data.packages.PackageVersion;
 	import com.apm.data.packages.RepositoryDefinition;
+	import com.apm.data.project.ProjectPackageDependency;
 	import com.apm.utils.JSONUtils;
 
 	import flash.filesystem.File;
@@ -45,7 +46,7 @@ package com.apm.data.project
 		private var _sourceFile:File;
 
 		private var _repositories:Vector.<RepositoryDefinition>;
-		private var _dependencies:Vector.<PackageDependency>;
+		private var _dependencies:Vector.<ProjectPackageDependency>;
 		private var _configuration:Vector.<ProjectParameter>;
 		private var _buildTypes:Vector.<ProjectBuildType>;
 		private var _deployOptions:Object;
@@ -62,7 +63,7 @@ package com.apm.data.project
 			_data = {};
 
 			_repositories = new <RepositoryDefinition>[];
-			_dependencies = new <PackageDependency>[];
+			_dependencies = new <ProjectPackageDependency>[];
 			_configuration = new <ProjectParameter>[];
 			_buildTypes = new <ProjectBuildType>[];
 			_deployOptions = {};
@@ -86,10 +87,10 @@ package com.apm.data.project
 
 			if (_data.hasOwnProperty( "dependencies" ))
 			{
-				_dependencies = new Vector.<PackageDependency>();
+				_dependencies = new Vector.<ProjectPackageDependency>();
 				for each (var dep:Object in _data.dependencies)
 				{
-					_dependencies.push( new PackageDependency().fromObject( dep ) );
+					_dependencies.push( new ProjectPackageDependency().fromObject( dep ) );
 				}
 			}
 
@@ -260,11 +261,11 @@ package com.apm.data.project
 		public function get repositories():Vector.<RepositoryDefinition> { return _repositories; }
 
 
-		public function get dependencies():Vector.<PackageDependency>
+		public function get dependencies():Vector.<ProjectPackageDependency>
 		{
 			if (_dependencies == null)
 			{
-				_dependencies = new Vector.<PackageDependency>();
+				_dependencies = new Vector.<ProjectPackageDependency>();
 			}
 			return _dependencies;
 		}
@@ -720,7 +721,7 @@ package com.apm.data.project
 		 */
 		public function clearPackageDependencies():ProjectDefinition
 		{
-			_dependencies = new Vector.<PackageDependency>();
+			_dependencies = new Vector.<ProjectPackageDependency>();
 			return this;
 		}
 
@@ -757,7 +758,7 @@ package com.apm.data.project
 		 *
 		 * @return <code>ProjectDefinition</code> instance for chaining calls
 		 */
-		public function addPackageDependency( dependency:PackageDependency ):ProjectDefinition
+		public function addPackageDependency( dependency:ProjectPackageDependency ):ProjectDefinition
 		{
 			if (hasDependency( dependency.identifier ))
 			{
@@ -790,9 +791,9 @@ package com.apm.data.project
 		 *
 		 * @return The <code>PackageDependency</code> or <code>null</code> if not found.
 		 */
-		public function getPackageDependency( identifier:String ):PackageDependency
+		public function getPackageDependency( identifier:String ):ProjectPackageDependency
 		{
-			for each (var dep:PackageDependency in _dependencies)
+			for each (var dep:ProjectPackageDependency in _dependencies)
 			{
 				if (PackageIdentifier.isEquivalent( dep.identifier, identifier ))
 				{
@@ -869,6 +870,25 @@ package com.apm.data.project
 				{
 					if (pa.equals( pb )) return true;
 				}
+			}
+			return false;
+		}
+
+
+		public function shouldDelayLoadPackage( packageIdentifier:String, buildType:String = null ):Boolean
+		{
+			var dep:ProjectPackageDependency = getPackageDependency( packageIdentifier );
+			if (dep != null)
+			{
+				if (dep.delayLoad != "none")
+				{
+					return dep.delayLoad == "true";
+				}
+			}
+			var param:ProjectParameter = getConfigurationParam( "delayLoad", buildType );
+			if (param != null)
+			{
+				return (param.value == "true");
 			}
 			return false;
 		}

--- a/client/src/com/apm/data/project/ProjectPackageDependency.as
+++ b/client/src/com/apm/data/project/ProjectPackageDependency.as
@@ -1,79 +1,38 @@
 /**
- * @author 		Michael Archbold (https://michaelarchbold.com)
- * @created		31/5/2021
+ * @author Michael Archbold (https://michaelarchbold.com)
+ * @created 17/10/2025
  */
-package com.apm.data.packages
+package com.apm.data.project
 {
 	import com.apm.SemVerRange;
+	import com.apm.data.packages.PackageDependency;
 
-	/**
-	 * Represents a simple dependency reference either in a package definition file
-	 * or the project definition file.
-	 * <br/>
-	 *
-	 * Note: Dependencies from the repository server do not use this format,
-	 * they supply PackageVersion with populated PackageDefinition for a more complete specification
-	 *
-	 */
-	public class PackageDependency
+	public class ProjectPackageDependency extends PackageDependency
 	{
 		////////////////////////////////////////////////////////
-		//  CONSTANTS
+		//	CONSTANTS
 		//
 
-		private static const TAG:String = "PackageDependency";
+		private static const TAG:String = "ProjectPackageDependency";
 
 
 		////////////////////////////////////////////////////////
-		//  VARIABLES
+		//	VARIABLES
 		//
 
-		public var identifier:String;
-		public var version:SemVerRange;
-		public var source:String;
-
-		protected var _singleLineOutput:Boolean = false;
+		public var delayLoad:String = "none";
 
 
 		////////////////////////////////////////////////////////
-		//  FUNCTIONALITY
+		//	FUNCTIONALITY
 		//
 
-		public function PackageDependency()
+		public function ProjectPackageDependency()
 		{
 		}
 
 
-		public function setIdentifier( identifier:String ):PackageDependency
-		{
-			this.identifier = identifier;
-			return this;
-		}
-
-
-		public function setVersion( version:SemVerRange ):PackageDependency
-		{
-			this.version = version;
-			return this;
-		}
-
-
-		public function setSource( source:String ):PackageDependency
-		{
-			this.source = source;
-			return this;
-		}
-
-
-		public function toString():String
-		{
-			return (identifier == null ? "none" : identifier)
-					+ "@" + (version == null ? "unknown" : version.toString())
-					+ (source == null ? "" : " [" + source + "]");
-		}
-
-
-		public function toObject( forceObjectOutput:Boolean = false ):Object
+		override public function toObject( forceObjectOutput:Boolean = false ):Object
 		{
 			if (_singleLineOutput && !forceObjectOutput)
 			{
@@ -82,16 +41,17 @@ package com.apm.data.packages
 			else
 			{
 				var o:Object = {
-					id       : identifier,
-					version  : version.toString()
+					id     : identifier,
+					version: version.toString()
 				};
 				if (source != null) o.source = source;
+				if (delayLoad != "none") o.delayLoad = delayLoad;
 				return o;
 			}
 		}
 
 
-		public function fromObject( data:Object ):PackageDependency
+		override public function fromObject( data:Object ):PackageDependency
 		{
 			if (data != null)
 			{
@@ -123,11 +83,15 @@ package com.apm.data.packages
 					if (data.hasOwnProperty( "version" )) this.version = SemVerRange.fromString( data["version"] );
 					if (data.hasOwnProperty( "source" )) this.source = data["source"];
 					if (data.hasOwnProperty( "package" )) this.identifier = data["package"].identifier;
+					if (data.hasOwnProperty( "delayLoad" )) this.delayLoad = data["delayLoad"];
 				}
 			}
 			return this;
 		}
 
-	}
+		////////////////////////////////////////////////////////
+		//	EVENT HANDLERS
+		//
 
+	}
 }

--- a/version.config
+++ b/version.config
@@ -1,6 +1,6 @@
 #Tue, 11 Mar 2025 13:47:09 +1000
 
 version_major=2
-version_minor=1
+version_minor=2
 version_build=0
 version_preview=


### PR DESCRIPTION
This update includes some additional outputs from the `view` and `list` commands allowing: 
- display of a packages dependencies with `apm view PACKAGEID VERSION` (specifying a version will display dependencies)
- display of all installed packages including dependencies with `apm list --deps` 

Additionally I have added a project config value called `delayLoad` which allows you to set the delay load attribute for native extensions in the generated application descriptor:

```
apm project config set delayLoad true
``` 

### Updates

feat(list): add flag to list command that outputs all installed dependencies: apm list --deps (resolves https://github.com/airsdk/apm/issues/226)
feat(install, app-descriptor): initial ability to set delayLoad value for all extensions (resolves https://github.com/airsdk/apm/issues/224)
feat(view): add output of package dependencies when a specific version is viewed (resolves https://github.com/airsdk/apm/issues/225)